### PR TITLE
[FIX] wrong sign at lines 35 / 36 of tax statement which is used for …

### DIFF
--- a/l10n_de_tax_statement/models/l10n_de_tax_statement_2018.py
+++ b/l10n_de_tax_statement/models/l10n_de_tax_statement_2018.py
@@ -277,9 +277,7 @@ def _finalize_lines_2018(lines):
     _33b = lines['33']['tax']
     lines['34']['tax'] = lines['34']['tax'] * -1
     _34b = lines['34']['tax']
-    lines['35']['tax'] = lines['35']['tax'] * -1
     _35b = lines['35']['tax']
-    lines['36']['tax'] = lines['36']['tax'] * -1
     _36b = lines['36']['tax']
     # calculate reverse of lines 48 - line 52 base
     lines['48']['base'] = lines['48']['base'] * -1

--- a/l10n_de_tax_statement/models/l10n_de_tax_statement_2019.py
+++ b/l10n_de_tax_statement/models/l10n_de_tax_statement_2019.py
@@ -256,9 +256,7 @@ def _finalize_lines_2019(lines):
     _33b = lines['33']['tax']
     lines['34']['tax'] = lines['34']['tax'] * -1
     _34b = lines['34']['tax']
-    lines['35']['tax'] = lines['35']['tax'] * -1
     _35b = lines['35']['tax']
-    lines['36']['tax'] = lines['36']['tax'] * -1
     _36b = lines['36']['tax']
     # calculate reverse of lines 48 - line 50 base
     lines['48']['base'] = lines['48']['base'] * -1


### PR DESCRIPTION
After Germany temporarily lowered the VAT from 19% / 7% to 16% / 5%, I noticed that the sign at column tax in line 35 is wrong. The same should probably also apply to line 36, since the taxes were not calculated by percentage in the "_finalize_lines_2019" method.

https://github.com/OCA/l10n-germany/blob/3ccf97a413f6d3f07e4d916eaa706f06d7b88a75/l10n_de_tax_statement/models/l10n_de_tax_statement_2019.py#L259

Closes #73