### PR TITLE
[FIX] datev_export_xml: Fix call of sorted for pickings

### DIFF
--- a/datev_export_xml/models/account_move.py
+++ b/datev_export_xml/models/account_move.py
@@ -63,7 +63,7 @@ class AccountMove(models.Model):
             pickings = self.mapped("invoice_line_ids.purchase_order_id.picking_ids")
 
         if pickings:
-            return pickings.sorted("date DESC")[0].date.date()
+            return pickings.sorted("date", reverse=True)[0].date.date()
 
         _logger.info("Invoice date used as delivery date.")
         return self.invoice_date


### PR DESCRIPTION
Backport of a bug discovered with #126 when reading the delivery date of invoices.