### PR TITLE
[IMP][FIX][14.0] datev_export_xml: Validation and small issues

### DIFF
--- a/datev_export_xml/models/account_move.py
+++ b/datev_export_xml/models/account_move.py
@@ -38,6 +38,7 @@ class AccountMove(models.Model):
         help="When finishing a datev export the processed invoices are marked as exported.\n"
         "If you need to export the invoices again, set this field to False.",
     )
+    datev_validation = fields.Text()
 
     def datev_format_total(self, value, prec=2):
         self.ensure_one()

--- a/datev_export_xml/models/datev_export.py
+++ b/datev_export_xml/models/datev_export.py
@@ -121,6 +121,9 @@ class DatevExport(models.Model):
         compute="_compute_datev_filesize",
     )
 
+    problematic_invoices_count = fields.Integer(
+        compute="_compute_problematic_invoices_count"
+    )
     invoice_ids = fields.Many2many(comodel_name="account.move", string="Invoices")
     invoices_count = fields.Integer(
         string="Invoices Count", compute="_compute_invoices_count", store=True
@@ -148,6 +151,13 @@ class DatevExport(models.Model):
     def _compute_datev_filesize(self):
         for r in self.with_context(bin_size=True):
             r.datev_filesize = r.datev_file
+
+    @api.depends("invoice_ids")
+    def _compute_problematic_invoices_count(self):
+        for r in self:
+            r.problematic_invoices_count = len(
+                r.invoice_ids.filtered("datev_validation")
+            )
 
     @api.depends("invoice_ids")
     def _compute_invoices_count(self):
@@ -250,6 +260,8 @@ class DatevExport(models.Model):
             self.write({"exception_info": msg, "state": "failed"})
             _logger.exception(e)
 
+        self._compute_problematic_invoices_count()
+
     @api.model
     def cron_run_pending_export(self):
         """
@@ -345,6 +357,16 @@ class DatevExport(models.Model):
             }
         )
 
+    def action_validate(self):
+        generator = self.env["datev.xml.generator"]
+        for invoice in self.invoice_ids:
+            try:
+                generator.generate_xml_invoice(invoice)
+            except UserError:
+                pass
+
+        self._compute_problematic_invoices_count()
+
     def action_done(self):
         self.filtered(lambda r: r.state in ["running", "failed"]).write(
             {
@@ -385,10 +407,21 @@ class DatevExport(models.Model):
                 )
             r.write({"state": "draft"})
 
+    def action_show_invalid_invoices_view(self):
+        tree_view = self.env.ref("datev_export_xml.view_move_datev_validation")
+        return {
+            "type": "ir.actions.act_window",
+            "view_mode": "tree,form",
+            "views": [[tree_view.id, "tree"], [False, "form"]],
+            "res_model": "account.move",
+            "target": "current",
+            "name": _("Problematic Invoices"),
+            "domain": [("id", "in", self.invoice_ids.filtered("datev_validation").ids)],
+        }
+
     def action_show_related_invoices_view(self):
         return {
             "type": "ir.actions.act_window",
-            "view_type": "form",
             "view_mode": "tree,kanban,form",
             "res_model": "account.move",
             "target": "current",
@@ -403,7 +436,7 @@ class DatevExport(models.Model):
         return res
 
     def write(self, vals):
-        super().write(vals)
+        res = super().write(vals)
         if any(
             r in vals
             for r in [
@@ -420,7 +453,7 @@ class DatevExport(models.Model):
                 super(DatevExport, r).write(
                     {"invoice_ids": [(6, 0, r.get_invoices().ids)]}
                 )
-        return True
+        return res
 
     @api.model
     def create(self, vals):

--- a/datev_export_xml/views/account_invoice_view.xml
+++ b/datev_export_xml/views/account_invoice_view.xml
@@ -13,6 +13,18 @@
         </field>
     </record>
 
+    <record id="view_move_datev_validation" model="ir.ui.view">
+        <field name="model">account.move</field>
+        <field name="mode">primary</field>
+        <field name="priority">800</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name" decoration-bf="1" />
+                <field name="datev_validation" />
+            </tree>
+        </field>
+    </record>
+
     <record id="view_account_invoice_filter" model="ir.ui.view">
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_account_invoice_filter" />

--- a/datev_export_xml/views/datev_export_views.xml
+++ b/datev_export_xml/views/datev_export_views.xml
@@ -86,6 +86,12 @@
                         confirm="Do you really want to set the export to draft?"
                     />
                     <button
+                        name="action_validate"
+                        type="object"
+                        string="Validate"
+                        attrs="{'invisible':  [('state', '=', 'done')]}"
+                    />
+                    <button
                         name="action_pending"
                         type="object"
                         string="Ready for Export"
@@ -145,6 +151,20 @@
                                     <field name="invoices_count" />
                                 </span>
                                 <span class="o_stat_text">Invoices</span>
+                            </div>
+                        </button>
+                        <button
+                            class="oe_stat_button oe_read_only"
+                            name="action_show_invalid_invoices_view"
+                            icon="fa-exclamation"
+                            type="object"
+                            attrs="{'invisible': [('problematic_invoices_count', '=', 0)]}"
+                        >
+                            <div class="o_form_field o_stat_info">
+                                <span class="o_stat_value">
+                                    <field name="problematic_invoices_count" />
+                                </span>
+                                <span class="o_stat_text">Problems</span>
                             </div>
                         </button>
                     </div>

--- a/datev_export_xml/views/templates.xml
+++ b/datev_export_xml/views/templates.xml
@@ -3,7 +3,7 @@
     <template id="export_party">
         <address
             t-att-name="(partner.display_name or '')[:50]"
-            t-att-street="(partner.street or '')[:40]"
+            t-att-street="' '.join([partner.street or '', partner.street2 or ''])[:40]"
             t-att-zip="partner.zip or ''"
             t-att-city="partner.city or ''"
             t-att-country="partner.country_id.code or ''"
@@ -24,9 +24,15 @@
 
     <template id="export_invoice_line_item">
         <price_line_amount
+            t-if="prices['total_included']"
             t-att-currency="line.currency_id.name"
             t-att-gross_price_line_amount="doc.datev_format_total(prices['total_included'])"
             t-att-net_price_line_amount="doc.datev_format_total(prices['total_excluded'])"
+            t-att-tax="doc.datev_format_total(line.tax_ids.amount)"
+        />
+        <price_line_amount
+            t-else=""
+            t-att-currency="line.currency_id.name"
             t-att-tax="doc.datev_format_total(line.tax_ids.amount)"
         />
 
@@ -42,7 +48,7 @@
         <t t-set="prices" t-value="line.datev_price_information()" />
 
         <invoice_item_list
-            t-if="line.product_id"
+            t-if="line.product_id and prices['total_excluded']"
             t-call="datev_export_xml.export_invoice_line_item"
             t-att-product_id="line.product_id.default_code"
             t-att-description_short="(line.name or line.product_id.name)[:40]"
@@ -51,10 +57,24 @@
             t-att-quantity="'%.02f' % line.quantity"
         />
         <invoice_item_list
+            t-if="line.product_id"
+            t-call="datev_export_xml.export_invoice_line_item"
+            t-att-product_id="line.product_id.default_code"
+            t-att-description_short="(line.name or line.product_id.name)[:40]"
+            t-att-order_unit="line.product_uom_id.name"
+            t-att-quantity="'%.02f' % line.quantity"
+        />
+        <invoice_item_list
+            t-elif="not line.display_type and prices['total_excluded']"
+            t-call="datev_export_xml.export_invoice_line_item"
+            t-att-description_short="(line.name or '')[:40]"
+            t-att-net_product_price="doc.datev_format_total(prices['total_excluded'], 3)"
+            t-att-quantity="'%.02f' % line.quantity"
+        />
+        <invoice_item_list
             t-elif="not line.display_type"
             t-call="datev_export_xml.export_invoice_line_item"
-            t-att-description_short="line.name or ''"
-            t-att-net_product_price="doc.datev_format_total(prices['total_excluded'], 3)"
+            t-att-description_short="(line.name or '')[:40]"
             t-att-quantity="'%.02f' % line.quantity"
         />
     </template>


### PR DESCRIPTION
**Fixes:**
- When you create an invoice line without product but with a longer description the `description_short` of `invoice_item_list` can get longer than 40 characters
- When you have a discount of 100% or something like free shipping the `net_product_price` of `invoice_item_list` would be 0 but DATEV doesn't allow 0 for those (mysteries of DATEV but I guess because no movement happened between the accounts)

**Improvement:**
It's inconvenient if there are errors in the invoices when rendering the ZIP archive because it stops at the first error. This is why I added a validation button and view with problematic invoices to jump into them and fix them one by one before trying to generate the ZIP.