### PR TITLE
[16.0][IMP] datev_export_xml: Improve handling and download of bigger files

### DIFF
--- a/datev_export_xml/__init__.py
+++ b/datev_export_xml/__init__.py
@@ -7,4 +7,4 @@
 # @author Grzegorz Grzelak
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from . import models
+from . import controllers, models

--- a/datev_export_xml/__manifest__.py
+++ b/datev_export_xml/__manifest__.py
@@ -10,7 +10,7 @@
 
 {
     "name": "Datev Export XML",
-    "version": "16.0.1.0.1",
+    "version": "16.0.1.1.1",
     "category": "Accounting",
     "license": "AGPL-3",
     "author": "Guenter Selbert, Thorsten Vocks, Maciej Wichowski, Daniela Scarpa, "

--- a/datev_export_xml/controllers/__init__.py
+++ b/datev_export_xml/controllers/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2022-2024 initOS GmbH
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import main

--- a/datev_export_xml/controllers/main.py
+++ b/datev_export_xml/controllers/main.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2022-2024 initOS GmbH
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import base64
+import logging
+
+from odoo import http
+from odoo.http import request, send_file
+
+from odoo.addons.web.controllers.main import Home
+
+_logger = logging.getLogger(__name__)
+
+
+class DatevHome(Home):
+    @http.route("/datev/xml/download/<int:export_id>", type="http", auth="user")
+    def datev_xml_download_attachment(self, export_id):
+        export = request.env["datev.export.xml"].search([("id", "=", export_id)])
+
+        if not export.attachment_id:
+            return request.not_found()
+
+        att = export.attachment_id
+
+        if att.store_fname:
+            full_path = att._full_path(att.store_fname)
+            return send_file(
+                full_path,
+                filename=att.name,
+                mimetype=att.mimetype,
+                as_attachment=True,
+            )
+
+        return request.make_response(
+            base64.b64decode(att.datas),
+            [
+                ("Content-Type", att.mimetype),
+                ("Content-Disposition", f'attachment; filename="{att.name}"'),
+            ],
+        )

--- a/datev_export_xml/controllers/main.py
+++ b/datev_export_xml/controllers/main.py
@@ -7,15 +7,15 @@ import logging
 from odoo import http
 from odoo.http import request, send_file
 
-from odoo.addons.web.controllers.main import Home
+from odoo.addons.web.controllers.home import Home
 
 _logger = logging.getLogger(__name__)
 
 
 class DatevHome(Home):
-    @http.route("/datev/xml/download/<int:export_id>", type="http", auth="user")
-    def datev_xml_download_attachment(self, export_id):
-        export = request.env["datev.export.xml"].search([("id", "=", export_id)])
+    @http.route("/datev/xml/download/<int:line_id>", type="http", auth="user")
+    def datev_xml_download_attachment(self, line_id):
+        export = request.env["datev.export.xml.line"].search([("id", "=", line_id)])
 
         if not export.attachment_id:
             return request.not_found()

--- a/datev_export_xml/demo/export_data.xml
+++ b/datev_export_xml/demo/export_data.xml
@@ -260,6 +260,9 @@
     <record id="customer_child" model="res.partner">
       <field name="name">A-Customer Child</field>
       <field name="type">contact</field>
+      <field name="street">Straße 1</field>
+      <field name="zip">12345</field>
+      <field name="city">Berlin</field>
       <field name="parent_id" ref="customer_parent" />
       <field name="vat">BE0477472701</field>
       <field name="country_id" ref="base.de" />

--- a/datev_export_xml/i18n/de.po
+++ b/datev_export_xml/i18n/de.po
@@ -398,9 +398,12 @@ msgstr "Dateigröße"
 #, python-format
 msgid ""
 "Filtered Export of %(count)s Documents\n"
-" Date Range: %(start)s-%(end)s\n"
+"Date Range: %(start)s-%(stop)s\n"
 "Types: %(types)s"
 msgstr ""
+"Gefilterter Export von %(count)s Dokumente\n"
+"Datumsbereich: %(start)s-%(stop)s\n"
+"Typen: %(types)s"
 
 #. module: datev_export_xml
 #: model:ir.model.fields,field_description:datev_export_xml.field_datev_export_xml__message_follower_ids
@@ -551,9 +554,11 @@ msgstr ""
 #: code:addons/datev_export_xml/models/datev_export.py:0
 #, python-format
 msgid ""
-"Manually Doc Export of %(count)s Documents \n"
+"Manual Export of %(count)s Documents\n"
 "Numbers: %(names)s"
 msgstr ""
+"Manueller Export von %(count)s Documenten \n"
+"Nummern: %(names)s"
 
 #. module: datev_export_xml
 #: model:ir.model.fields,field_description:datev_export_xml.field_datev_export_xml__manually_document_selection

--- a/datev_export_xml/migrations/16.0.1.1.1/post-migrate.py
+++ b/datev_export_xml/migrations/16.0.1.1.1/post-migrate.py
@@ -1,0 +1,34 @@
+# © 2023 initOS GmbH
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    query = """
+        SELECT id, attachment_id FROM datev_export_xml
+        WHERE attachment_id IS NOT NULL
+    """
+    env.cr.execute(query)
+
+    for export_id, attachment_id in env.cr.fetchall():
+        export = env["datev.export.xml"].browse(export_id)
+        attachment = env["ir.attachment"].browse(attachment_id)
+
+        _logger.info(f"Migrating attachment of {export}")
+
+        line = export.line_ids.create(
+            {
+                "attachment_id": attachment_id,
+                "export_id": export_id,
+                "invoice_ids": [(6, 0, export.invoice_ids.ids)],
+            }
+        )
+
+        attachment.write({"res_model": line._name, "res_id": line.id})

--- a/datev_export_xml/models/__init__.py
+++ b/datev_export_xml/models/__init__.py
@@ -18,4 +18,4 @@ from . import (
     res_config_settings,
 )
 
-from . import datev_export  # isort:skip
+from . import datev_export, datev_export_line  # isort:skip

--- a/datev_export_xml/models/account_move.py
+++ b/datev_export_xml/models/account_move.py
@@ -43,6 +43,7 @@ class AccountMove(models.Model):
         help="When finishing a datev export the processed invoices are marked as exported.\n"
         "If you need to export the invoices again, set this field to False.",
     )
+    datev_validation = fields.Text()
 
     def datev_format_total(self, value, prec=2):
         self.ensure_one()

--- a/datev_export_xml/models/datev_export.py
+++ b/datev_export_xml/models/datev_export.py
@@ -374,8 +374,8 @@ class DatevExport(models.Model):
 
             try:
                 generator.generate_xml_invoice(invoice)
-            except UserError:
-                pass
+            except UserError as e:
+                _logger.exception(e)
 
         self._compute_problematic_invoices_count()
 

--- a/datev_export_xml/models/datev_export.py
+++ b/datev_export_xml/models/datev_export.py
@@ -14,7 +14,6 @@ import time
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import human_size
 
 _logger = logging.getLogger(__name__)
 
@@ -111,22 +110,23 @@ class DatevExport(models.Model):
         readonly=True,
         states={"draft": [("readonly", False)]},
     )
-    attachment_id = fields.Many2one(
-        comodel_name="ir.attachment", string="Attachment", required=False, readonly=True
+    line_ids = fields.One2many(
+        "datev.export.xml.line",
+        "export_id",
+        "Lines",
     )
-    datev_filename = fields.Char(
-        "ZIP filename", readonly=True, related="attachment_id.name"
-    )
-    datev_filesize = fields.Char(
-        "Filesize",
-        compute="_compute_datev_filesize",
-    )
+    line_count = fields.Integer(compute="_compute_line_count")
 
     problematic_invoices_count = fields.Integer(
         compute="_compute_problematic_invoices_count"
     )
     invoice_ids = fields.Many2many(comodel_name="account.move", string="Invoices")
-    invoices_count = fields.Integer(compute="_compute_invoices_count", store=True)
+    invoices_count = fields.Integer(
+        string="Total Invoices", compute="_compute_invoices_count", store=True
+    )
+    invoices_exported_count = fields.Integer(
+        string="Exported Invoices", compute="_compute_invoices_count", store=True
+    )
 
     manually_document_selection = fields.Boolean(default=False)
     exception_info = fields.Text(readonly=True)
@@ -146,22 +146,23 @@ class DatevExport(models.Model):
         tracking=True,
     )
 
-    @api.depends("attachment_id", "attachment_id.file_size")
-    def _compute_datev_filesize(self):
-        for r in self:
-            r.datev_filesize = human_size(r.attachment_id.file_size)
+    @api.depends("line_ids")
+    def _compute_line_count(self):
+        for rec in self:
+            rec.line_count = len(rec.line_ids)
 
     @api.depends("invoice_ids")
     def _compute_problematic_invoices_count(self):
-        for r in self:
-            r.problematic_invoices_count = len(
-                r.invoice_ids.filtered("datev_validation")
+        for rec in self:
+            rec.problematic_invoices_count = len(
+                rec.invoice_ids.filtered("datev_validation")
             )
 
-    @api.depends("invoice_ids")
+    @api.depends("invoice_ids", "line_ids", "line_ids.invoice_ids")
     def _compute_invoices_count(self):
-        for r in self:
-            r.invoices_count = len(r.invoice_ids)
+        for rec in self:
+            rec.invoices_count = len(rec.invoice_ids)
+            rec.invoices_exported_count = len(rec.mapped("line_ids.invoice_ids"))
 
     @api.constrains("export_invoice", "export_refund", "export_type")
     def validate_types(self):
@@ -178,14 +179,6 @@ class DatevExport(models.Model):
                     "you want to export!"
                 )
             )
-
-    def datev_download(self):
-        self.ensure_one()
-        return {
-            "type": "ir.actions.act_url",
-            "url": f"/datev/xml/download/{self.id}",
-            "target": "self",
-        }
 
     def get_type_list(self):
         list_invoice_type = []
@@ -222,49 +215,67 @@ class DatevExport(models.Model):
             )
         return self.env["account.move"].search(search_clause)
 
+    def _get_zip(self):
+        generator = self.generate_zip(
+            self.invoice_ids - self.mapped("line_ids.invoice_ids"),
+            self.check_xsd,
+        )
+
+        for index, (zip_file, invoices) in enumerate(generator, 1):
+            if not self.manually_document_selection:
+                description = _(
+                    "Filtered Export of %(count)s Documents\n"
+                    "Date Range: %(start)s-%(stop)s\nTypes: %(types)s",
+                    count=len(invoices),
+                    start=self.date_start,
+                    stop=self.date_stop,
+                    types=", ".join(self.get_type_list()),
+                )
+            else:
+                description = _(
+                    "Manual Export of %(count)s Documents\n" "Numbers: %(names)s",
+                    count=len(invoices),
+                    names=", ".join(self.invoice_ids.mapped("name")),
+                )
+
+            attachment = self.env["ir.attachment"].create(
+                {
+                    "name": time.strftime(f"%Y-%m-%d_%H%M-{index}.zip"),
+                    "datas": zip_file,
+                    "res_model": "datev.export.xml",
+                    "res_id": self.id,
+                    "res_field": "attachment_id",
+                    "description": description,
+                }
+            )
+            self.line_ids.sudo().create(
+                {
+                    "export_id": self.id,
+                    "attachment_id": attachment.id,
+                    "invoice_ids": [(6, 0, invoices.ids)],
+                }
+            )
+
+            # Huge numbers of invoices can lead to cron timeouts. Commit after
+            # each package and continue. When the timeout hits the job is still
+            # in running and is set to pending in the cron (hanging job) and
+            # will continue with the next package
+            if self.env.context.get("datev_autocommit"):
+                # pylint: disable=invalid-commit
+                self.env.cr.commit()
+
     def get_zip(self):
-        self = self.with_context(bin_size=False)
+        self.ensure_one()
+
         try:
-            if self.attachment_id:
-                self.attachment_id.unlink()
-
             self.write({"state": "running", "exception_info": None})
-            with self.env.cr.savepoint():
-                zip_file = self.generate_zip(
-                    self.invoice_ids,
-                    self.check_xsd,
-                )
-                if not self.manually_document_selection:
-                    description = _(
-                        "Filtered Export of %(count)s Documents\n "
-                        "Date Range: %(start)s-%(end)s\nTypes: %(types)s",
-                        count=len(self.invoice_ids),
-                        start=self.date_start,
-                        end=self.date_stop,
-                        types=", ".join(self.get_type_list()),
-                    )
-                else:
-                    description = _(
-                        "Manually Doc Export of %(count)s Documents \nNumbers: %(names)s",
-                        count=len(self.invoice_ids),
-                        names=", ".join(self.invoice_ids.mapped("name")),
-                    )
-
-                attachment = self.env["ir.attachment"].create(
-                    {
-                        "name": time.strftime("%Y_%m_%d_%H_%M") + ".zip",
-                        "datas": zip_file,
-                        "res_model": "datev.export.xml",
-                        "res_id": self.id,
-                        "res_field": "attachment_id",
-                        "description": description,
-                    }
-                )
-                self.write({"attachment_id": attachment.id, "state": "done"})
+            self.with_context(bin_size=False)._get_zip()
+            if self.invoices_count == self.invoices_exported_count:
+                self.write({"state": "done"})
         except Exception as e:
+            _logger.exception(e)
             msg = e.name if hasattr(e, "name") else str(e)
             self.write({"exception_info": msg, "state": "failed"})
-            _logger.exception(e)
 
         self._compute_problematic_invoices_count()
 
@@ -279,14 +290,25 @@ class DatevExport(models.Model):
         )
         hanging_datev_exports.write({"state": "pending"})
         datev_export = self.search(
-            [("state", "=", "pending"), ("manually_document_selection", "=", False)],
+            [
+                ("state", "in", ("running", "pending")),
+                ("manually_document_selection", "=", False),
+            ],
+            # Favor hanging jobs
+            order="state DESC",
             limit=1,
         )
-        if datev_export:
-            datev_export.with_user(datev_export.create_uid.id).get_zip()
+
+        if not datev_export:
+            return
+
+        datev_export.with_user(datev_export.create_uid.id).with_context(
+            datev_autocommit=True
+        ).get_zip()
+
+        if datev_export.state == "done":
             datev_export._create_activity()
             datev_export.invoice_ids.write({"datev_exported": True})
-        return True
 
     def export_zip(self):
         self.ensure_one()
@@ -297,7 +319,6 @@ class DatevExport(models.Model):
         else:
             self.invoice_ids = [(6, 0, self.get_invoices().ids)]
             self.action_pending()
-        return True
 
     @api.model
     def export_zip_invoice(self, invoice_ids=None):
@@ -363,6 +384,9 @@ class DatevExport(models.Model):
             }
         )
 
+    def action_invalidate_lines(self):
+        self.line_ids.write({"invalidated": True})
+
     def action_validate(self):
         generator = self.env["datev.xml.generator"]
         for invoice in self.invoice_ids:
@@ -412,12 +436,12 @@ class DatevExport(models.Model):
             )
 
     def action_draft(self):
-        for r in self:
-            if r.state == "running":
-                raise ValidationError(
-                    _("It's not allowed to set a running export to draft!")
-                )
-            r.write({"state": "draft"})
+        if "running" in self.mapped("state"):
+            raise ValidationError(
+                _("It's not allowed to set a running export to draft!")
+            )
+
+        self.write({"state": "draft", "line_ids": [(5,)]})
 
     def action_show_invalid_invoices_view(self):
         tree_view = self.env.ref("datev_export_xml.view_move_datev_validation")
@@ -462,6 +486,7 @@ class DatevExport(models.Model):
             for r in self:
                 if r.manually_document_selection:
                     continue
+
                 super(DatevExport, r).write(
                     {"invoice_ids": [(6, 0, r.get_invoices().ids)]}
                 )

--- a/datev_export_xml/models/datev_export.py
+++ b/datev_export_xml/models/datev_export.py
@@ -417,13 +417,6 @@ class DatevExport(models.Model):
                 r.invoice_ids = [(6, 0, r.get_invoices().ids)]
             if r.invoices_count == 0:
                 raise ValidationError(_("No invoices/refunds for export!"))
-            if r.invoices_count > 4999 and r.check_xsd:
-                raise ValidationError(
-                    _(
-                        "The numbers of invoices/refunds is limited to 4999 by DATEV! "
-                        "Please decrease the number of documents or deactivate Check XSD."
-                    )
-                )
             if r.state == "running":
                 raise ValidationError(
                     _("It's not allowed to set an already running export to pending!")

--- a/datev_export_xml/models/datev_export.py
+++ b/datev_export_xml/models/datev_export.py
@@ -244,7 +244,6 @@ class DatevExport(models.Model):
                     "datas": zip_file,
                     "res_model": "datev.export.xml",
                     "res_id": self.id,
-                    "res_field": "attachment_id",
                     "description": description,
                 }
             )

--- a/datev_export_xml/models/datev_export.py
+++ b/datev_export_xml/models/datev_export.py
@@ -367,6 +367,12 @@ class DatevExport(models.Model):
         generator = self.env["datev.xml.generator"]
         for invoice in self.invoice_ids:
             try:
+                generator._check_invoices(invoice)
+            except ValueError as e:
+                invoice.datev_validation = str(e)
+                continue
+
+            try:
                 generator.generate_xml_invoice(invoice)
             except UserError:
                 pass

--- a/datev_export_xml/models/datev_export_line.py
+++ b/datev_export_xml/models/datev_export_line.py
@@ -1,0 +1,53 @@
+# © 2024 initOS GmbH
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.tools import human_size
+
+
+class DatevExportPackage(models.Model):
+    _name = "datev.export.xml.line"
+    _description = "DATEV XML Export Line"
+
+    export_id = fields.Many2one("datev.export.xml", readonly=True)
+    attachment_id = fields.Many2one("ir.attachment", ondelete="cascade", readonly=True)
+    filename = fields.Char(readonly=True, related="attachment_id.name")
+    filesize = fields.Char(compute="_compute_filesize")
+    invoice_ids = fields.Many2many("account.move", readonly=True)
+    invoices_count = fields.Integer(
+        string="Invoices", compute="_compute_invoices_count", store=True
+    )
+
+    @api.depends("invoice_ids")
+    def _compute_invoices_count(self):
+        for line in self:
+            line.invoices_count = len(line.invoice_ids)
+
+    @api.depends("attachment_id", "attachment_id.file_size")
+    def _compute_filesize(self):
+        for line in self:
+            line.filesize = human_size(line.attachment_id.file_size)
+
+    def action_datev_download(self):
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_url",
+            "url": f"/datev/xml/download/{self.id}",
+            "target": "self",
+        }
+
+    def action_open_invoices(self):
+        return {
+            "type": "ir.actions.act_window",
+            "view_mode": "tree,kanban,form",
+            "res_model": "account.move",
+            "target": "current",
+            "name": _("Included Invoices"),
+            "domain": [("id", "in", self.invoice_ids.ids)],
+        }
+
+    def unlink(self):
+        attachments = self.mapped("attachment_id")
+        if attachments:
+            attachments.unlink()
+        return super().unlink()

--- a/datev_export_xml/models/datev_xml_generator.py
+++ b/datev_export_xml/models/datev_xml_generator.py
@@ -86,7 +86,9 @@ class DatevXmlGenerator(models.AbstractModel):
                 "Document_v050.xsd",
             )
 
-        return "document.xml", etree.tostring(root)
+        return "document.xml", etree.tostring(
+            root, xml_declaration=True, encoding="UTF-8"
+        )
 
     @api.model
     def generate_xml_invoice(self, invoice, check_xsd=True):
@@ -106,4 +108,4 @@ class DatevXmlGenerator(models.AbstractModel):
                 invoice=invoice,
             )
 
-        return doc_name, etree.tostring(root)
+        return doc_name, etree.tostring(root, xml_declaration=True, encoding="UTF-8")

--- a/datev_export_xml/models/datev_xml_generator.py
+++ b/datev_export_xml/models/datev_xml_generator.py
@@ -24,16 +24,23 @@ class DatevXmlGenerator(models.AbstractModel):
     _description = "DATEV XML Generator"
 
     @api.model
-    def check_xml_file(self, doc_name, root, xsd=None):
+    def check_xml_file(self, doc_name, root, xsd=None, invoice=None):
         if not xsd:
             xsd = "Document_v050.xsd"
 
         schema = tools.file_open(f"datev_export_xml/xsd_files/{xsd}")
         try:
+            if invoice:
+                invoice.datev_validation = False
+
             schema = etree.XMLSchema(etree.parse(schema))
             schema.assertValid(root)
         except (etree.DocumentInvalid, etree.XMLSyntaxError) as e:
             _logger.warning(etree.tostring(root))
+
+            if invoice:
+                invoice.datev_validation = str(e)
+
             raise UserError(
                 _(
                     "Wrong Data in XML file!\nTry to solve the problem with "
@@ -96,6 +103,7 @@ class DatevXmlGenerator(models.AbstractModel):
                 doc_name,
                 root,
                 "Belegverwaltung_online_invoice_v050.xsd",
+                invoice=invoice,
             )
 
         return doc_name, etree.tostring(root)

--- a/datev_export_xml/models/datev_zip_generator.py
+++ b/datev_export_xml/models/datev_zip_generator.py
@@ -65,7 +65,7 @@ class DatevZipGenerator(models.AbstractModel):
             included |= invoice
 
             # The file can grow slightly bigger than the limit
-            if buf.tell() > package_limit:
+            if buf.tell() > package_limit or len(included) >= 4500:
                 # Finalize the file
                 zip_file.writestr(*self.generate_xml_document(included, check_xsd))
                 zip_file.close()

--- a/datev_export_xml/models/res_company.py
+++ b/datev_export_xml/models/res_company.py
@@ -49,3 +49,17 @@ class ResCompany(models.Model):
         default="odoo",
         required=True,
     )
+
+    datev_package_limit = fields.Integer(
+        string="Package Limit in MB",
+        default=100,
+    )
+
+    _sql_constraints = [
+        (
+            "check_package_limit",
+            # DATEV only allows 465 MB and we leave some space
+            "CHECK(datev_package_limit >= 20 AND datev_package_limit <= 400)",
+            _("Package Limit for DATEV must be between 20MB and 400MB"),
+        )
+    ]

--- a/datev_export_xml/models/res_config_settings.py
+++ b/datev_export_xml/models/res_config_settings.py
@@ -32,3 +32,8 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.datev_customer_order_ref",
         readonly=False,
     )
+
+    datev_package_limit = fields.Integer(
+        related="company_id.datev_package_limit",
+        readonly=False,
+    )

--- a/datev_export_xml/security/ir.model.access.csv
+++ b/datev_export_xml/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_datev_export_xml,access_datev_export_xml,model_datev_export_xml,account.group_account_manager,1,1,1,1
+access_datev_export_xml_line,access_datev_export_xml_line,model_datev_export_xml_line,account.group_account_manager,1,1,0,1

--- a/datev_export_xml/tests/test_datev_export.py
+++ b/datev_export_xml/tests/test_datev_export.py
@@ -101,9 +101,9 @@ class TestDatevExport(TransactionCase):
             doc_data = z.read(doc_file)
             inv_data = z.read(inv_file)
             # document.xml
-            doc_root = etree.fromstring(doc_data.decode("utf-8"))
+            doc_root = etree.fromstring(doc_data)
             # invoice.xml file
-            inv_root = etree.fromstring(inv_data.decode("utf-8"))
+            inv_root = etree.fromstring(inv_data)
             for i in inv_root:
                 invoice_xml.update(i.attrib)
 

--- a/datev_export_xml/tests/test_datev_export.py
+++ b/datev_export_xml/tests/test_datev_export.py
@@ -86,7 +86,7 @@ class TestDatevExport(TransactionCase):
         export.check_valid_data(export.invoice_ids)
         invoice = export.invoice_ids[0].name
         invoice = invoice.replace("/", "-")
-        zip_data = base64.b64decode(export.datev_file)
+        zip_data = base64.b64decode(export.attachment_id.datas)
         fp = io.BytesIO()
         fp.write(zip_data)
         zipfile.is_zipfile(fp)
@@ -373,7 +373,7 @@ class TestDatevExport(TransactionCase):
         start_date = refund.invoice_date
         end_date = refund.invoice_date_due
         datev_export = self.create_customer_datev_export(start_date, end_date)
-        self.assertEqual(datev_export.datev_file, False)
+        self.assertFalse(datev_export.attachment_id)
         self.assertEqual(
             datev_export.client_number,
             self.env.company.datev_client_number,
@@ -398,7 +398,6 @@ class TestDatevExport(TransactionCase):
         self.assertTrue(datev_export.datev_filesize)
         self.assertEqual(datev_export.state, "done")
 
-        self.assertTrue(datev_export.datev_file)
         self.assertTrue(datev_export.attachment_id)
         file_list = ["document.xml", inv_number + ".xml", inv_number + ".pdf"]
         res = self._check_filecontent(datev_export)
@@ -424,7 +423,7 @@ class TestDatevExport(TransactionCase):
         datev_export = self.create_vendor_datev_export(start_date, end_date)
 
         attachment = self.update_attachment(attachment, refund)
-        self.assertEqual(datev_export.datev_file, False)
+        self.assertFalse(datev_export.attachment_id)
         self.assertEqual(
             datev_export.client_number,
             self.env.company.datev_client_number,
@@ -449,7 +448,6 @@ class TestDatevExport(TransactionCase):
         # self.DatevExportObj.refresh()
         self.assertEqual(datev_export.state, "done")
 
-        self.assertTrue(datev_export.datev_file)
         self.assertTrue(datev_export.attachment_id)
         file_list = ["document.xml", f"{inv_number}.xml", f"{inv_number}.pdf"]
         res = self._check_filecontent(datev_export)
@@ -473,7 +471,7 @@ class TestDatevExport(TransactionCase):
         start_date = invoice.invoice_date
         end_date = invoice.invoice_date_due
         datev_export = self.create_customer_datev_export(start_date, end_date)
-        self.assertEqual(datev_export.datev_file, False)
+        self.assertFalse(datev_export.attachment_id)
         self.assertEqual(
             datev_export.client_number,
             self.env.company.datev_client_number,
@@ -498,7 +496,6 @@ class TestDatevExport(TransactionCase):
         # self.DatevExportObj.refresh()
         self.assertEqual(datev_export.state, "done")
 
-        self.assertTrue(datev_export.datev_file)
         self.assertTrue(datev_export.attachment_id)
         file_list = ["document.xml", inv_number + ".xml", inv_number + ".pdf"]
         res = self._check_filecontent(datev_export)
@@ -524,7 +521,7 @@ class TestDatevExport(TransactionCase):
         datev_export = self.create_vendor_datev_export(start_date, end_date)
 
         attachment = self.update_attachment(attachment, invoice)
-        self.assertEqual(datev_export.datev_file, False)
+        self.assertFalse(datev_export.attachment_id)
         self.assertEqual(
             datev_export.client_number,
             self.env.company.datev_client_number,
@@ -548,7 +545,6 @@ class TestDatevExport(TransactionCase):
         # self.DatevExportObj.refresh()
         self.assertEqual(datev_export.state, "done")
 
-        self.assertTrue(datev_export.datev_file)
         self.assertTrue(datev_export.attachment_id)
         file_list = ["document.xml", f"{inv_number}.xml", f"{inv_number}.pdf"]
         res = self._check_filecontent(datev_export)
@@ -570,7 +566,7 @@ class TestDatevExport(TransactionCase):
         self.assertEqual(invoice.state, "posted")
 
         datev_export = self.create_customer_datev_export_manually(invoice)
-        self.assertEqual(datev_export.datev_file, False)
+        self.assertFalse(datev_export.attachment_id)
         self.assertEqual(
             datev_export.client_number,
             self.env.company.datev_client_number,
@@ -593,7 +589,6 @@ class TestDatevExport(TransactionCase):
             datev_mode="datev_export"
         ).export_zip()
         self.assertEqual(datev_export.state, "done")
-        self.assertTrue(datev_export.datev_file)
         self.assertTrue(datev_export.attachment_id)
         file_list = ["document.xml", inv_number + ".xml", inv_number + ".pdf"]
         res = self._check_filecontent(datev_export)
@@ -749,7 +744,7 @@ class TestDatevExport(TransactionCase):
                 "export_type": "out",
             }
         )
-        self.assertEqual(datev_export.datev_file, False)
+        self.assertFalse(datev_export.attachment_id)
         self.assertEqual(
             datev_export.client_number,
             self.env.company.datev_client_number,

--- a/datev_export_xml/views/account_invoice_view.xml
+++ b/datev_export_xml/views/account_invoice_view.xml
@@ -13,6 +13,18 @@
         </field>
     </record>
 
+    <record id="view_move_datev_validation" model="ir.ui.view">
+        <field name="model">account.move</field>
+        <field name="mode">primary</field>
+        <field name="priority">800</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name" decoration-bf="1" />
+                <field name="datev_validation" />
+            </tree>
+        </field>
+    </record>
+
     <record id="view_account_invoice_filter" model="ir.ui.view">
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_account_invoice_filter" />

--- a/datev_export_xml/views/datev_export_views.xml
+++ b/datev_export_xml/views/datev_export_views.xml
@@ -112,7 +112,7 @@
                         name="export_zip"
                         type="object"
                         class="oe_highlight"
-                        attrs="{'invisible':  ['|', ('datev_file', '!=', False), ('manually_document_selection', '=', False)]}"
+                        attrs="{'invisible':  ['|', ('attachment_id', '!=', False), ('manually_document_selection', '=', False)]}"
                         confirm="The creation of the file can take some time! Do you really want to proceed!"
                     />
                     <button
@@ -120,7 +120,7 @@
                         name="export_zip"
                         type="object"
                         class=""
-                        attrs="{'invisible': ['|', ('datev_file', '=', False), ('manually_document_selection', '=', False)]}"
+                        attrs="{'invisible': ['|', ('attachment_id', '=', False), ('manually_document_selection', '=', False)]}"
                         confirm="The creation of the file can take some time! Do you really want to create the DATEV file again?"
                     />
 
@@ -181,10 +181,10 @@
                             <field name="check_xsd" />
                         </group>
                         <group string="Download File" col="1">
-                            <field name="datev_filename" invisible="1" />
+                            <field name="attachment_id" invisible="1" />
                             <div>
                                 <span
-                                    attrs="{'invisible': [('datev_file', '!=', False)]}"
+                                    attrs="{'invisible': [('attachment_id', '!=', False)]}"
                                 >
                                     <strong>
                                         <big>
@@ -193,23 +193,21 @@
                                     </strong>
                                 </span>
                                 <span
-                                    attrs="{'invisible': [('datev_file', '=', False)]}"
+                                    attrs="{'invisible': [('attachment_id', '=', False)]}"
                                 >
-                                    <span>
+                                    <button
+                                        name="datev_download"
+                                        type="object"
+                                        class="btn oe_link oe_inline"
+                                    >
                                         <big>
-                                            <big>
-                                                <field
-                                                    name="datev_file"
-                                                    filename="datev_filename"
-                                                    nolabel="1"
-                                                />
-                                                <i class="ml8">(<field
-                                                        name="datev_filesize"
-                                                    />)
-                                                </i>
-                                            </big>
+                                            <field name="datev_filename" readonly="1" />
+                                            <i class="ml8">(<field
+                                                    name="datev_filesize"
+                                                />)
+                                            </i>
                                         </big>
-                                    </span>
+                                    </button>
                                 </span>
                             </div>
 
@@ -287,7 +285,7 @@
                         name="export_zip"
                         type="object"
                         class="oe_highlight"
-                        attrs="{'invisible':  ['|', ('datev_file', '!=', False), ('manually_document_selection', '=', True)]}"
+                        attrs="{'invisible':  ['|', ('attachment_id', '!=', False), ('manually_document_selection', '=', True)]}"
                         confirm="The creation of the file will be done in background and may take some time! When the file is created or an exception occurs, an activity will be applied to you."
                     />
 
@@ -296,7 +294,7 @@
                         name="export_zip"
                         type="object"
                         class=""
-                        attrs="{'invisible': ['|', ('datev_file', '=', False), ('manually_document_selection', '=', True)]}"
+                        attrs="{'invisible': ['|', ('attachment_id', '=', False), ('manually_document_selection', '=', True)]}"
                         confirm="Do you really want to create the DATEV file again? The creation of the file will be done in background and may take some time! When the file is created or an exception occurs, an activity will be applied to you."
                     />
 
@@ -306,7 +304,7 @@
                         name="export_zip"
                         type="object"
                         class="oe_highlight"
-                        attrs="{'invisible':  ['|', ('datev_file', '!=', False), ('manually_document_selection', '=', False)]}"
+                        attrs="{'invisible':  ['|', ('attachment_id', '!=', False), ('manually_document_selection', '=', False)]}"
                         confirm="The creation of the file can take some time! Do you really want to proceed!"
                     />
 
@@ -315,7 +313,7 @@
                         name="export_zip"
                         type="object"
                         class=""
-                        attrs="{'invisible': ['|', ('datev_file', '=', False), ('manually_document_selection', '=', False)]}"
+                        attrs="{'invisible': ['|', ('attachment_id', '=', False), ('manually_document_selection', '=', False)]}"
                         confirm="The creation of the file can take some time! Do you really want to create the DATEV file again?"
                     />
 
@@ -353,9 +351,6 @@
                 <field name="manually_document_selection" invisible="True" />
                 <field name="date_start" />
                 <field name="date_stop" />
-                <field name="datev_file" filename="datev_filename" widget="binary" />
-                <field name="datev_filesize" />
-                <field name="datev_filename" invisible="1" />
                 <field name="invoices_count" />
                 <field name="state" />
             </tree>

--- a/datev_export_xml/views/datev_export_views.xml
+++ b/datev_export_xml/views/datev_export_views.xml
@@ -118,7 +118,7 @@
                         name="export_zip"
                         type="object"
                         class="oe_highlight"
-                        attrs="{'invisible':  ['|', ('attachment_id', '!=', False), ('manually_document_selection', '=', False)]}"
+                        attrs="{'invisible':  ['|', ('line_count', '>', 0), ('manually_document_selection', '=', False)]}"
                         confirm="The creation of the file can take some time! Do you really want to proceed!"
                     />
                     <button
@@ -126,7 +126,7 @@
                         name="export_zip"
                         type="object"
                         class=""
-                        attrs="{'invisible': ['|', ('attachment_id', '=', False), ('manually_document_selection', '=', False)]}"
+                        attrs="{'invisible': ['|', ('line_count', '>', 0), ('manually_document_selection', '=', False)]}"
                         confirm="The creation of the file can take some time! Do you really want to create the DATEV file again?"
                     />
 
@@ -148,6 +148,7 @@
                         >
                             <div class="o_form_field o_stat_info">
                                 <span class="o_stat_value">
+                                    <field name="invoices_exported_count" /> /
                                     <field name="invoices_count" />
                                 </span>
                                 <span class="o_stat_text">Invoices</span>
@@ -183,8 +184,7 @@
                             <field name="date_stop" />
                             <!-- <field name="period_id"/> -->
                         </group>
-                    </group>
-                    <group>
+
                         <group string="General Settings">
                             <field
                                 name="client_number"
@@ -200,45 +200,6 @@
                             />
                             <field name="check_xsd" />
                         </group>
-                        <group string="Download File" col="1">
-                            <field name="attachment_id" invisible="1" />
-                            <div>
-                                <span
-                                    attrs="{'invisible': [('attachment_id', '!=', False)]}"
-                                >
-                                    <strong>
-                                        <big>
-                                            The zip file can be downloaded here after creation!
-                                        </big>
-                                    </strong>
-                                </span>
-                                <span
-                                    attrs="{'invisible': [('attachment_id', '=', False)]}"
-                                >
-                                    <button
-                                        name="datev_download"
-                                        type="object"
-                                        class="btn oe_link oe_inline"
-                                    >
-                                        <big>
-                                            <field name="datev_filename" readonly="1" />
-                                            <i class="ml8">(<field
-                                                    name="datev_filesize"
-                                                />)
-                                            </i>
-                                        </big>
-                                    </button>
-                                </span>
-                            </div>
-
-                            <div class="oe_grey">
-                                <i
-                                    class="fa fa-exclamation-triangle mr4"
-                                    aria-hidden="true"
-                                />
-                                Downloading large files may fail due to server settings!
-                            </div>
-                        </group>
                     </group>
 
                     <group
@@ -253,6 +214,40 @@
                             class="alert alert-danger"
                             role="alert"
                         />
+                    </group>
+
+                    <group string="Generated Files">
+                        <field name="line_count" invisible="1" />
+                        <span attrs="{'invisible': [('line_count', '>', 0)]}">
+                            <strong
+                            >The zip files can be downloaded here after creation!</strong>
+                        </span>
+
+                        <field
+                            name="line_ids"
+                            nolabel="1"
+                            colspan="2"
+                            options="{'no_open': True, 'no_create': True}"
+                            attrs="{'invisible': [('line_count', '=', 0)]}"
+                        >
+                            <tree editable="bottom">
+                                <field name="filename" />
+                                <field name="filesize" />
+                                <field name="invoices_count" />
+                                <button
+                                    name="action_datev_download"
+                                    string="Download"
+                                    type="object"
+                                    class="btn btn-primary"
+                                />
+                                <button
+                                    name="action_open_invoices"
+                                    string="Show Invoices"
+                                    type="object"
+                                    class="btn btn-primary"
+                                />
+                            </tree>
+                        </field>
                     </group>
 
                     <group
@@ -305,7 +300,7 @@
                         name="export_zip"
                         type="object"
                         class="oe_highlight"
-                        attrs="{'invisible':  ['|', ('attachment_id', '!=', False), ('manually_document_selection', '=', True)]}"
+                        attrs="{'invisible':  ['|', ('line_count', '>', 0), ('manually_document_selection', '=', True)]}"
                         confirm="The creation of the file will be done in background and may take some time! When the file is created or an exception occurs, an activity will be applied to you."
                     />
 
@@ -314,7 +309,7 @@
                         name="export_zip"
                         type="object"
                         class=""
-                        attrs="{'invisible': ['|', ('attachment_id', '=', False), ('manually_document_selection', '=', True)]}"
+                        attrs="{'invisible': ['|', ('line_count', '=', 0), ('manually_document_selection', '=', True)]}"
                         confirm="Do you really want to create the DATEV file again? The creation of the file will be done in background and may take some time! When the file is created or an exception occurs, an activity will be applied to you."
                     />
 
@@ -324,7 +319,7 @@
                         name="export_zip"
                         type="object"
                         class="oe_highlight"
-                        attrs="{'invisible':  ['|', ('attachment_id', '!=', False), ('manually_document_selection', '=', False)]}"
+                        attrs="{'invisible':  ['|', ('line_count', '>', 0), ('manually_document_selection', '=', False)]}"
                         confirm="The creation of the file can take some time! Do you really want to proceed!"
                     />
 
@@ -333,7 +328,7 @@
                         name="export_zip"
                         type="object"
                         class=""
-                        attrs="{'invisible': ['|', ('attachment_id', '=', False), ('manually_document_selection', '=', False)]}"
+                        attrs="{'invisible': ['|', ('line_count', '=', 0), ('manually_document_selection', '=', False)]}"
                         confirm="The creation of the file can take some time! Do you really want to create the DATEV file again?"
                     />
 

--- a/datev_export_xml/views/datev_export_views.xml
+++ b/datev_export_xml/views/datev_export_views.xml
@@ -86,6 +86,12 @@
                         confirm="Do you really want to set the export to draft?"
                     />
                     <button
+                        name="action_validate"
+                        type="object"
+                        string="Validate"
+                        attrs="{'invisible':  [('state', '=', 'done')]}"
+                    />
+                    <button
                         name="action_pending"
                         type="object"
                         string="Ready for Export"
@@ -145,6 +151,20 @@
                                     <field name="invoices_count" />
                                 </span>
                                 <span class="o_stat_text">Invoices</span>
+                            </div>
+                        </button>
+                        <button
+                            class="oe_stat_button oe_read_only"
+                            name="action_show_invalid_invoices_view"
+                            icon="fa-exclamation"
+                            type="object"
+                            attrs="{'invisible': [('problematic_invoices_count', '=', 0)]}"
+                        >
+                            <div class="o_form_field o_stat_info">
+                                <span class="o_stat_value">
+                                    <field name="problematic_invoices_count" />
+                                </span>
+                                <span class="o_stat_text">Problems</span>
                             </div>
                         </button>
                     </div>

--- a/datev_export_xml/views/res_config_settings_views.xml
+++ b/datev_export_xml/views/res_config_settings_views.xml
@@ -86,7 +86,9 @@
                         </div>
                     </div>
 
-                    <div class="o_setting_left_pane" />
+                    <div class="o_setting_left_pane">
+                        <field name="datev_export_state" class="o_light_label" />
+                    </div>
                     <div class="o_setting_right_pane">
                         <span class="o_form_label">Export State</span>
                         <span
@@ -99,13 +101,26 @@
                             If set, the invoices are marked as exported when finishing a Datev export.
                             Only not yet exported invoices are suggested for next Datev export.
                         </div>
+                    </div>
+
+                    <div class="o_setting_left_pane" />
+                    <div class="o_setting_right_pane">
+                        <span class="o_form_label">Package Limit</span>
+                        <span
+                            class="fa fa-lg fa-building-o"
+                            title="Values set here are company-specific."
+                            aria-label="Values set here are company-specific."
+                            groups="base.group_multi_company"
+                        />
+                        <div class="text-muted">
+                            The package size in MB before a new ZIP archive is created.
+                            The value should be between 20 MB and 400 MB
+                        </div>
                         <div class="content-group">
-                            <div class="mt16">
-                                <field
-                                    name="datev_export_state"
-                                    class="o_light_label"
-                                />
-                            </div>
+                            <field
+                                name="datev_package_limit"
+                                class="o_light_label"
+                            /> in MB
                         </div>
                     </div>
                 </div>

--- a/datev_export_xml/views/templates.xml
+++ b/datev_export_xml/views/templates.xml
@@ -3,7 +3,7 @@
     <template id="export_party">
         <address
             t-att-name="(partner.display_name or '')[:50]"
-            t-att-street="(partner.street or '')[:40]"
+            t-att-street="' '.join([partner.street or '', partner.street2 or ''])[:40]"
             t-att-zip="partner.zip or ''"
             t-att-city="partner.city or ''"
             t-att-country="partner.country_id.code or ''"
@@ -24,9 +24,15 @@
 
     <template id="export_invoice_line_item">
         <price_line_amount
+            t-if="prices['total_included']"
             t-att-currency="line.currency_id.name"
             t-att-gross_price_line_amount="doc.datev_format_total(prices['total_included'])"
             t-att-net_price_line_amount="doc.datev_format_total(prices['total_excluded'])"
+            t-att-tax="doc.datev_format_total(line.tax_ids.amount)"
+        />
+        <price_line_amount
+            t-else=""
+            t-att-currency="line.currency_id.name"
             t-att-tax="doc.datev_format_total(line.tax_ids.amount)"
         />
 
@@ -42,7 +48,7 @@
         <t t-set="prices" t-value="line.datev_price_information()" />
 
         <invoice_item_list
-            t-if="line.product_id"
+            t-if="line.product_id and prices['total_excluded']"
             t-call="datev_export_xml.export_invoice_line_item"
             t-att-product_id="line.product_id.default_code"
             t-att-description_short="(line.name or line.product_id.name)[:40]"
@@ -51,10 +57,24 @@
             t-att-quantity="'%.02f' % line.quantity"
         />
         <invoice_item_list
+            t-if="line.product_id"
+            t-call="datev_export_xml.export_invoice_line_item"
+            t-att-product_id="line.product_id.default_code"
+            t-att-description_short="(line.name or line.product_id.name)[:40]"
+            t-att-order_unit="line.product_uom_id.name"
+            t-att-quantity="'%.02f' % line.quantity"
+        />
+        <invoice_item_list
+            t-elif="not line.display_type and prices['total_excluded']"
+            t-call="datev_export_xml.export_invoice_line_item"
+            t-att-description_short="(line.name or '')[:40]"
+            t-att-net_product_price="doc.datev_format_total(prices['total_excluded'], 3)"
+            t-att-quantity="'%.02f' % line.quantity"
+        />
+        <invoice_item_list
             t-elif="not line.display_type"
             t-call="datev_export_xml.export_invoice_line_item"
-            t-att-description_short="line.name or ''"
-            t-att-net_product_price="doc.datev_format_total(prices['total_excluded'], 3)"
+            t-att-description_short="(line.name or '')[:40]"
             t-att-quantity="'%.02f' % line.quantity"
         />
     </template>

--- a/datev_export_xml/views/templates.xml
+++ b/datev_export_xml/views/templates.xml
@@ -37,7 +37,7 @@
         />
 
         <accounting_info
-            t-att-account_no="line.account_id.code or ''"
+            t-att-account_no="(line.account_id.code or '').lstrip('0')"
             t-att-cost_category_id="line.datev_analytic_account().code or ''"
             t-att-booking_text="(line.name or line.product_id.name or '')[:60]"
             t-att-bu_code="line.tax_ids.l10n_de_datev_code or '0'"

--- a/datev_export_xml/views/templates.xml
+++ b/datev_export_xml/views/templates.xml
@@ -57,7 +57,7 @@
             t-att-quantity="'%.02f' % line.quantity"
         />
         <invoice_item_list
-            t-if="line.product_id"
+            t-elif="line.product_id"
             t-call="datev_export_xml.export_invoice_line_item"
             t-att-product_id="line.product_id.default_code"
             t-att-description_short="(line.name or line.product_id.name)[:40]"


### PR DESCRIPTION
Currently when big files are handled the server might respond with 500 MemoryError when opening the list or form view of the datev xml exports. The worker processes are hitting the RAM limits and will be killed.

#158 