### PR TITLE
[14.0][FIX] datev_export_xml : Deleting record of datev.export.xml fails

### DIFF
--- a/datev_export_xml/models/datev_export.py
+++ b/datev_export_xml/models/datev_export.py
@@ -451,7 +451,7 @@ class DatevExport(models.Model):
         }
 
     def unlink(self):
-        attachments = self.mapped("attachment_id")
+        attachments = self.line_ids.mapped("attachment_id")
         res = super().unlink()
         attachments.exists().unlink()
         return res


### PR DESCRIPTION
datev_export_xml : Deleting record of datev.export.xml fails.
Error info:
```
Traceback (most recent call last):
  File "/opt/odoo/lib/odoo/odoo/http.py", line 652, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/lib/odoo/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
KeyError: 'attachment_id'
```