### PR TITLE
[17.0][IMP] l10n_de_mis_reports: Add Gewinn des Jahres to Balance Sheet report

### DIFF
--- a/l10n_de_mis_reports/data/mis_report_bs_skr03.xml
+++ b/l10n_de_mis_reports/data/mis_report_bs_skr03.xml
@@ -673,13 +673,30 @@
       <field name="auto_expand_accounts_style_id" ref="style_l10n_de_level3_accounts" />
       <field name="sequence">570</field>
     </record>
+    <record model="mis.report.kpi" id="mis_report_bs_skr03_gewinn_des_jahres">
+        <field name="report_id" ref="mis_report_bs_skr03" />
+        <field name="name">gewinn_des_jahres</field>
+        <field name="description">5. Gewinn des Jahres</field>
+        <field
+            name="expression"
+        >bale[('user_type_id', '=', ref('account.data_unaffected_earnings').id)] + bale['|', ('user_type_id', '=', ref('account.data_account_type_revenue').id),('user_type_id', '=', ref('account.data_account_type_expenses').id)]-balu['|', ('user_type_id', '=', ref('account.data_account_type_revenue').id),('user_type_id', '=', ref('account.data_account_type_expenses').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id" ref="style_l10n_de_level3" />
+        <field name="auto_expand_accounts" eval="True" />
+        <field
+            name="auto_expand_accounts_style_id"
+            ref="style_l10n_de_level3_accounts"
+        />
+        <field name="sequence">575</field>
+    </record>
     <record model="mis.report.kpi" id="mis_report_bs_skr03_total_gewinnruecklage">
       <field name="report_id" ref="mis_report_bs_skr03" />
       <field name="name">total_gewinnruecklage</field>
       <field name="description">Total III. Gewinnrücklage</field>
       <field
             name="expression"
-        >+ ruecklage_gesetzlich + ruecklage_eigene_anteile + ruecklage_satzung + ruecklage_andere_gewinne</field>
+        >+ ruecklage_gesetzlich + ruecklage_eigene_anteile + ruecklage_satzung + ruecklage_andere_gewinne + gewinn_des_jahres</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="style_l10n_de_level1_total" />

--- a/l10n_de_mis_reports/data/mis_report_bs_skr04.xml
+++ b/l10n_de_mis_reports/data/mis_report_bs_skr04.xml
@@ -660,13 +660,30 @@
       <field name="auto_expand_accounts_style_id" ref="style_l10n_de_level3_accounts" />
       <field name="sequence">570</field>
     </record>
+    <record model="mis.report.kpi" id="mis_report_bs_skr04_gewinn_des_jahres">
+        <field name="report_id" ref="mis_report_bs_skr04" />
+        <field name="name">gewinn_des_jahres</field>
+        <field name="description">5. Gewinn des Jahres</field>
+        <field
+            name="expression"
+        >bale[('user_type_id', '=', ref('account.data_unaffected_earnings').id)] + bale['|', ('user_type_id', '=', ref('account.data_account_type_revenue').id),('user_type_id', '=', ref('account.data_account_type_expenses').id)]-balu['|', ('user_type_id', '=', ref('account.data_account_type_revenue').id),('user_type_id', '=', ref('account.data_account_type_expenses').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id" ref="style_l10n_de_level3" />
+        <field name="auto_expand_accounts" eval="True" />
+        <field
+            name="auto_expand_accounts_style_id"
+            ref="style_l10n_de_level3_accounts"
+        />
+        <field name="sequence">575</field>
+    </record>
     <record model="mis.report.kpi" id="mis_report_bs_skr04_total_gewinnruecklage">
       <field name="report_id" ref="mis_report_bs_skr04" />
       <field name="name">total_gewinnruecklage</field>
       <field name="description">Total III. Gewinnrücklage</field>
       <field
             name="expression"
-        >+ ruecklage_gesetzlich + ruecklage_eigene_anteile + ruecklage_satzung + ruecklage_andere_gewinne</field>
+        >+ ruecklage_gesetzlich + ruecklage_eigene_anteile + ruecklage_satzung + ruecklage_andere_gewinne + gewinn_des_jahres</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="style_l10n_de_level1_total" />
@@ -835,7 +852,7 @@
       <field
             name="description"
         >4. Verbindlichkeiten aus Lieferungen u. Leistungen</field>
-      <field name="expression">bals[330%,331%,332%,333%,333%,334%]</field>
+      <field name="expression">bals[330%,331%,332%,333%,334%]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="style_l10n_de_level2" />


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/l10n-germany/pull/181
FWP from 15.0: https://github.com/OCA/l10n-germany/pull/182

Fixes #176 

Add Gewinn des Jahres to Balance Sheet report (similar to https://github.com/OCA/l10n-spain/blob/a0cf2cba66d8afa87d1bc0eab2b0a0774ab99629/l10n_es_mis_report/data/mis_report_balance_abreviated.xml#L527)

Please @pedrobaeza can you review it?

@Tecnativa TT54645