### PR TITLE
[13.0][IMP] l10n_de_skr04_mis_reports: Remove unnecessary l10n_generic_coa dependency

### DIFF
--- a/l10n_de_skr04_mis_reports/__manifest__.py
+++ b/l10n_de_skr04_mis_reports/__manifest__.py
@@ -14,7 +14,6 @@
     "depends": [
         "mis_builder",
         "l10n_de_skr04",
-        "l10n_generic_coa",
     ],  # OCA/account-financial-reporting
     "data": [
         "data/mis_report_styles.xml",


### PR DESCRIPTION
Remove unnecessary `l10n_generic_coa` dependency

The similar `l10n_de_skr03_mis_reports` module does not need that dependency.

The `l10n_generic_coa` dependency was added in the migration to 13.0 https://github.com/OCA/l10n-germany/pull/91 without argument. In v14 this dependency does not exist because it was migrated from 12.0 https://github.com/OCA/l10n-germany/pull/87 before the 13.0 migration was merged.

Please @pedrobaeza can you review it?

@Tecnativa TT54645