### PR TITLE
[FIX][14.0] l10n_de_tax_statement_zm: Adjust header of CSV

### DIFF
--- a/l10n_de_tax_statement_zm/models/l10n_de_tax_statement.py
+++ b/l10n_de_tax_statement_zm/models/l10n_de_tax_statement.py
@@ -183,7 +183,7 @@ class VatStatement(models.Model):
                 res[vat]["2_amount_products"] += zml.amount_products
                 res[vat]["3_amount_services"] += zml.amount_services
         lines = [
-            ["Laenderkennzeichen", "USt-IdNr.", "Betrag(Euro)", "Art der Leistung"]
+            ["Umsatzsteuer-Identifikationsnummer", "Betrag (Euro)", "Art der Leistung"]
         ]
         for vat in res:
             v = res[vat]


### PR DESCRIPTION
This fixes the header to only use 3 columns as defined in the newer version of the spec and copies the column names from the spec.

#195 

spec: https://www.elster.de/eportal/helpGlobal?themaGlobal=zmdo_import_eop