### PR TITLE
[17.0] FIX wrong expression at kpi gewinn_des_jahres and improved translations

### DIFF
--- a/l10n_de_mis_reports/README.rst
+++ b/l10n_de_mis_reports/README.rst
@@ -20,7 +20,7 @@ github repository.
 Configuration
 =============
 
-To configure this module, you need to go to 
+To configure this module, you need to go to
 Accounting > Reporting > MIS Reports and create report instance
 according to the desired time periods and using one of the following
 templates provided by this module:
@@ -35,7 +35,7 @@ German chart of account.
 Usage
 =====
 
-To use this module, you need to go to 
+To use this module, you need to go to
 Accounting > Reporting > MIS Reports and use the buttons
 available on the previously configured reports such as preview,
 export, add to dashboard.
@@ -63,6 +63,7 @@ Contributors
 * Thorsten Vocks <thorsten.vocks@openbig.org>
 * Stéphane Bidoul at ACSONE <stephane.bidoul@acsone.eu>
 * Virgine Dewulf <virginie@coopiteasy.be>
+* Günter Selbert <guenter.selbert@samsa-it.de>
 
 Maintainer
 ----------

--- a/l10n_de_mis_reports/__manifest__.py
+++ b/l10n_de_mis_reports/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "OpenBIG.org," "ACSONE SA/NV," "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-germany",
     "category": "Reporting",
-    "version": "17.0.1.1.0",
+    "version": "17.0.1.1.1",
     "license": "AGPL-3",
     "depends": [
         "mis_builder",  # OCA/account-financial-reporting

--- a/l10n_de_mis_reports/data/mis_report_bs_skr03.xml
+++ b/l10n_de_mis_reports/data/mis_report_bs_skr03.xml
@@ -679,7 +679,7 @@
         <field name="description">5. Gewinn des Jahres</field>
         <field
             name="expression"
-        >bale[('user_type_id', '=', ref('account.data_unaffected_earnings').id)] + bale['|', ('user_type_id', '=', ref('account.data_account_type_revenue').id),('user_type_id', '=', ref('account.data_account_type_expenses').id)]-balu['|', ('user_type_id', '=', ref('account.data_account_type_revenue').id),('user_type_id', '=', ref('account.data_account_type_expenses').id)]</field>
+        >bale[('account_type', '=', 'equity_unaffected')] + bale['|', ('account_type', '=', 'income'), ( 'account_type', '=', 'expense')] -balu['|', ('account_type', '=', 'income'),( 'account_type', '=', 'expense')]</field>
         <field name="type">num</field>
         <field name="compare_method">pct</field>
         <field name="style_id" ref="style_l10n_de_level3" />

--- a/l10n_de_mis_reports/data/mis_report_bs_skr04.xml
+++ b/l10n_de_mis_reports/data/mis_report_bs_skr04.xml
@@ -666,7 +666,7 @@
         <field name="description">5. Gewinn des Jahres</field>
         <field
             name="expression"
-        >bale[('user_type_id', '=', ref('account.data_unaffected_earnings').id)] + bale['|', ('user_type_id', '=', ref('account.data_account_type_revenue').id),('user_type_id', '=', ref('account.data_account_type_expenses').id)]-balu['|', ('user_type_id', '=', ref('account.data_account_type_revenue').id),('user_type_id', '=', ref('account.data_account_type_expenses').id)]</field>
+        >bale[('account_type', '=', 'equity_unaffected')] + bale['|', ('account_type', '=', 'income'), ( 'account_type', '=', 'expense')] -balu['|', ('account_type', '=', 'income'),( 'account_type', '=', 'expense')]</field>
         <field name="type">num</field>
         <field name="compare_method">pct</field>
         <field name="style_id" ref="style_l10n_de_level3" />

--- a/l10n_de_mis_reports/i18n/de.po
+++ b/l10n_de_mis_reports/i18n/de.po
@@ -390,13 +390,13 @@ msgstr ""
 #: model:mis.report,name:l10n_de_mis_reports.mis_report_bs_skr03
 #, fuzzy
 msgid "Balance Sheet (SKR03)"
-msgstr "Bilanz Auswertung"
+msgstr "Bilanz Auswertung (SKR03)"
 
 #. module: l10n_de_mis_reports
 #: model:mis.report,name:l10n_de_mis_reports.mis_report_bs_skr04
 #, fuzzy
 msgid "Balance Sheet (SKR04)"
-msgstr "Bilanz Auswertung"
+msgstr "Bilanz Auswertung (SKR04)"
 
 #. module: l10n_de_mis_reports
 #: model:mis.report.kpi,description:l10n_de_mis_reports.mis_report_pl_skr03_total_aufwendungen
@@ -512,7 +512,7 @@ msgstr "Bilanz für SKR03 Kontenplan Deutschland (§ 266 HGB)"
 #: model:mis.report,description:l10n_de_mis_reports.mis_report_bs_skr04
 #, fuzzy
 msgid "German Balance Sheet for SKR04 (§ 266 HGB)"
-msgstr "Bilanz für SKR03 Kontenplan Deutschland (§ 266 HGB)"
+msgstr "Bilanz für SKR04 Kontenplan Deutschland (§ 266 HGB)"
 
 #. module: l10n_de_mis_reports
 #: model:mis.report,description:l10n_de_mis_reports.mis_report_pl_skr03
@@ -608,13 +608,13 @@ msgstr ""
 #: model:mis.report,name:l10n_de_mis_reports.mis_report_pl_skr03
 #, fuzzy
 msgid "P&L Sheet (SKR03)"
-msgstr "Gewinn- und Verlustrechnung"
+msgstr "Gewinn- und Verlustrechnung (SKR03)"
 
 #. module: l10n_de_mis_reports
 #: model:mis.report,name:l10n_de_mis_reports.mis_report_pl_skr04
 #, fuzzy
 msgid "P&L Sheet (SKR04)"
-msgstr "Gewinn- und Verlustrechnung"
+msgstr "Gewinn- und Verlustrechnung (SKR04)"
 
 #. module: l10n_de_mis_reports
 #: model:mis.report.kpi,description:l10n_de_mis_reports.mis_report_bs_skr03_aktivseite


### PR DESCRIPTION
[FIX] better and correct translations. Replaced wrong expression kpi gewinn_des_jahres (balance sheets), which was selecting accounts by user_type_id (relation account.account.type) which was replaced since odoo v 16 by a simple selection field name account_type