### PR TITLE
[17.0][FIX] l10n_de_tax_statement: views to use column_invisible attribute and remove setup files

### DIFF
--- a/l10n_de_tax_statement/views/l10n_de_tax_statement_view.xml
+++ b/l10n_de_tax_statement/views/l10n_de_tax_statement_view.xml
@@ -115,16 +115,16 @@
                                     delete="false"
                                     limit="80"
                                 >
-                                    <field name="is_group" invisible="1" />
-                                    <field name="is_total" invisible="1" />
-                                    <field name="is_readonly" invisible="1" />
+                                    <field name="is_group" column_invisible="1" />
+                                    <field name="is_total" column_invisible="1" />
+                                    <field name="is_readonly" column_invisible="1" />
                                     <field name="code" readonly="1" />
                                     <field name="name" readonly="1" />
-                                    <field name="format_base" invisible="1" />
-                                    <field name="format_tax" invisible="1" />
+                                    <field name="format_base" column_invisible="1" />
+                                    <field name="format_tax" column_invisible="1" />
                                     <field
                                         name="base"
-                                        invisible="not format_base"
+                                        optional="show"
                                         readonly="is_readonly"
                                     />
                                     <button
@@ -136,7 +136,7 @@
                                     />
                                     <field
                                         name="tax"
-                                        invisible="not format_tax"
+                                        optional="show"
                                         readonly="is_readonly"
                                     />
                                     <button
@@ -191,7 +191,7 @@
                                     <field name="amount_tax" readonly="1" />
                                     <field
                                         name="l10n_de_tax_statement_include"
-                                        invisible="1"
+                                        column_invisible="1"
                                     />
                                     <button
                                         name="l10n_de_add_move_in_statement"

--- a/setup/l10n_de_tax_statement/odoo/addons/l10n_de_tax_statement
+++ b/setup/l10n_de_tax_statement/odoo/addons/l10n_de_tax_statement
@@ -1,1 +1,0 @@
-../../../../l10n_de_tax_statement

--- a/setup/l10n_de_tax_statement/setup.py
+++ b/setup/l10n_de_tax_statement/setup.py
@@ -1,6 +1,0 @@
-import setuptools
-
-setuptools.setup(
-    setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
-)


### PR DESCRIPTION
pre 18.0 migration improvements: https://github.com/OCA/l10n-germany/pull/190