### PR TITLE
[18.0][IMP] l10n_de_tax_statement: Adding mt-software-de as maintainer

### DIFF
--- a/l10n_de_tax_statement/__manifest__.py
+++ b/l10n_de_tax_statement/__manifest__.py
@@ -25,4 +25,5 @@
         ],
     },
     "installable": True,
+    "maintainers": ["mt-software-de"],
 }


### PR DESCRIPTION
As proposed and discussed at the Code Sprint in Hamburg.
I would like take care about the addon l10n_de_tax_statement.

@smaddlsoft @pniederlag @tv-openbig @OSevangelist