### PR TITLE
[ADD] l10n_de_account: rename menu 'Invoicing' -> 'Accounting'

### DIFF
--- a/l10n_de_account/README.rst
+++ b/l10n_de_account/README.rst
@@ -1,0 +1,38 @@
+Usage
+=====
+
+Activate Translation of German
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/hr/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Yu Weng <yweng@elegosoft.com>
+
+Do not contact contributors directly about support or help with technical issues.
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/l10n_de_account/__init__.py
+++ b/l10n_de_account/__init__.py
@@ -1,0 +1,8 @@
+from . import models
+from . import wizards
+
+
+def _l10n_de_account_post_init(env):
+    lang = env["res.lang"]
+    if lang._lang_get("de_DE"):
+        lang.update_menu_finance_de_translation()

--- a/l10n_de_account/__manifest__.py
+++ b/l10n_de_account/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2026 elego Software Solutions GmbH - Yu Weng
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Accounting for Germany",
+    "version": "18.0.1.0.0",
+    "license": "AGPL-3",
+    "category": "Account",
+    "author": "Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/l10n-germany",
+    "summary": "Change the menu from Invoicing to Accounting",
+    "depends": [
+        "account",
+    ],
+    "data": [
+        "views/account_menuitem.xml",
+        "views/res_config_settings_views.xml",
+    ],
+    "installable": True,
+    "auto_install": False,
+    "post_init_hook": "_l10n_de_account_post_init",
+}

--- a/l10n_de_account/i18n/de.po
+++ b/l10n_de_account/i18n/de.po
@@ -1,0 +1,31 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_de_account
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-30 17:27+0000\n"
+"PO-Revision-Date: 2026-04-30 17:27+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_de_account
+#: model_terms:ir.ui.view,arch_db:l10n_de_account.res_config_settings_view_form
+msgid "Accounting"
+msgstr "Buchhaltung"
+
+#. module: l10n_de_account
+#: model:ir.model,name:l10n_de_account.model_base_language_install
+msgid "Install Language"
+msgstr ""
+
+#. module: l10n_de_account
+#: model:ir.model,name:l10n_de_account.model_res_lang
+msgid "Languages"
+msgstr "Sprachen"

--- a/l10n_de_account/i18n/l10n_de_account.pot
+++ b/l10n_de_account/i18n/l10n_de_account.pot
@@ -1,0 +1,31 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_de_account
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-04-30 17:27+0000\n"
+"PO-Revision-Date: 2026-04-30 17:27+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_de_account
+#: model_terms:ir.ui.view,arch_db:l10n_de_account.res_config_settings_view_form
+msgid "Accounting"
+msgstr ""
+
+#. module: l10n_de_account
+#: model:ir.model,name:l10n_de_account.model_base_language_install
+msgid "Install Language"
+msgstr ""
+
+#. module: l10n_de_account
+#: model:ir.model,name:l10n_de_account.model_res_lang
+msgid "Languages"
+msgstr ""

--- a/l10n_de_account/models/__init__.py
+++ b/l10n_de_account/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_lang

--- a/l10n_de_account/models/res_lang.py
+++ b/l10n_de_account/models/res_lang.py
@@ -1,0 +1,35 @@
+# Copyright 2026 elego Software Solutions GmbH - Yu Weng
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class Lang(models.Model):
+    _inherit = "res.lang"
+
+    def toggle_active(self):
+        res = super().toggle_active()
+
+        if "de_DE" in [lang.code for lang in self.filtered(lambda L: L.active)]:
+            self.update_menu_finance_de_translation()
+
+        return res
+
+    def update_menu_finance_de_translation(self):
+        """In Odoo the inheritance mechanism is not yet implemented for menus.
+        Changing a menu item name doesn't create a new string to be translated
+        but overwrites the source string of the original module to which the menu
+        belongs to. This is a workaround that allows the translated string to be
+        modified in the same way.
+        """
+        menu_finance_id = self.env["ir.model.data"]._xmlid_to_res_id(
+            "account.menu_finance"
+        )
+        menu_finance = self.env["ir.ui.menu"].browse(menu_finance_id)
+
+        field_name = menu_finance._fields["name"]
+        translations = field_name._get_stored_translations(menu_finance)
+
+        translations["de_DE"] = "Buchhaltung"
+        self.env.cache.update_raw(menu_finance, field_name, [translations], dirty=True)
+        menu_finance.modified(["name"])

--- a/l10n_de_account/pyproject.toml
+++ b/l10n_de_account/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/l10n_de_account/views/account_menuitem.xml
+++ b/l10n_de_account/views/account_menuitem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="account.menu_finance" model="ir.ui.menu">
+        <field name="name">Accounting</field>
+    </record>
+</odoo>

--- a/l10n_de_account/views/res_config_settings_views.xml
+++ b/l10n_de_account/views/res_config_settings_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <app name="account" position="attributes">
+                <attribute name="string">Accounting</attribute>
+                <attribute name="data-string">Accounting</attribute>
+            </app>
+        </field>
+    </record>
+</odoo>

--- a/l10n_de_account/wizards/__init__.py
+++ b/l10n_de_account/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import base_language_install

--- a/l10n_de_account/wizards/base_language_install.py
+++ b/l10n_de_account/wizards/base_language_install.py
@@ -1,0 +1,18 @@
+# Copyright 2024 Sergio Zanchetta (PNLUG APS - Gruppo Odoo)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class BaseLanguageInstall(models.TransientModel):
+    _inherit = "base.language.install"
+
+    def lang_install(self):
+        res = super().lang_install()
+
+        lang = self.env["res.lang"]
+
+        if "de_DE" in self.lang_ids.mapped("code"):
+            lang.update_menu_finance_de_translation()
+
+        return res


### PR DESCRIPTION
Hi,
I have added a new module that changes the main menu and the "Invoicing" settings menu to "Accounting". This feature is also implemented in the module account_usability (in oca/account-financial-tools). However, we were unable to add the German translation for it. Therefore, I fixed it using the same approach as in oca/l10n-italy (see pull request
https://github.com/OCA/l10n-italy/pull/4298)

Other pull requests related to this feature in account-financial-tools can be found here:
https://github.com/OCA/account-financial-tools/pull/2243
https://github.com/OCA/account-financial-tools/pull/2249
