### PR TITLE
[18.0][FIX] datev_export_xml element not expected

### DIFF
--- a/datev_export_xml/views/templates.xml
+++ b/datev_export_xml/views/templates.xml
@@ -65,14 +65,14 @@
             t-att-quantity="'%.02f' % line.quantity"
         />
         <invoice_item_list
-            t-elif="not line.display_type and prices['total_excluded']"
+            t-elif="prices['total_excluded']"
             t-call="datev_export_xml.export_invoice_line_item"
             t-att-description_short="(line.name or '')[:40]"
             t-att-net_product_price="doc.datev_format_total(prices['total_excluded'], 3)"
             t-att-quantity="'%.02f' % line.quantity"
         />
         <invoice_item_list
-            t-elif="not line.display_type"
+            t-else=""
             t-call="datev_export_xml.export_invoice_line_item"
             t-att-description_short="(line.name or '')[:40]"
             t-att-quantity="'%.02f' % line.quantity"
@@ -144,7 +144,10 @@
                 t-att-payment_conditions_text="doc.invoice_payment_term_id.name"
             />
 
-            <t t-foreach="doc.invoice_line_ids" t-as="line">
+            <t
+                t-foreach="doc.invoice_line_ids.filtered(lambda l: l.display_type == 'product')"
+                t-as="line"
+            >
                 <t t-call="datev_export_xml.export_invoice_line" />
             </t>
 


### PR DESCRIPTION
This fixes an error which occurs when exporting certain invoices.

`Element '{http://xml.datev.de/bedi/tps/invoice/v050}total_amount': This element is not expected. Expected is one of ( {http://xml.datev.de/bedi/tps/invoice/v050}supplier_issuer, {http://xml.datev.de/bedi/tps/invoice/v050}payment_conditions, {http://xml.datev.de/bedi/tps/invoice/v050}additional_info_header, {http://xml.datev.de/bedi/tps/invoice/v050}invoice_item_list )., line 30`