### PR TITLE
created by mistake, please delete me

### DIFF
--- a/l10n_de_tax_statement/models/__init__.py
+++ b/l10n_de_tax_statement/models/__init__.py
@@ -5,3 +5,4 @@ from . import l10n_de_tax_statement_line
 from . import account_move
 from . import account_move_line
 from . import l10n_de_tax_statement_config
+from . import l10n_de_tax_statement_2026

--- a/l10n_de_tax_statement/models/l10n_de_tax_statement.py
+++ b/l10n_de_tax_statement/models/l10n_de_tax_statement.py
@@ -30,6 +30,12 @@ from .l10n_de_tax_statement_2021 import (
     _tax_statement_dict_2021,
     _totals_2021,
 )
+from .l10n_de_tax_statement_2026 import (
+    _finalize_lines_2026,
+    _map_tax_code_line_code_2026,
+    _tax_statement_dict_2026,
+    _totals_2026,
+)
 
 
 class VatStatement(models.Model):
@@ -45,7 +51,13 @@ class VatStatement(models.Model):
         readonly=False,
     )
     version = fields.Selection(
-        [("2018", "2018"), ("2019", "2019/2020"), ("2021", "2021/2022")], required=True
+        [
+            ("2018", "2018"),
+            ("2019", "2019/2020"),
+            ("2021", "2021/2022"),
+            ("2026", "2026"),
+        ],
+        required=True,
     )
     state = fields.Selection(
         [("draft", "Draft"), ("posted", "Posted"), ("final", "Final")],
@@ -178,7 +190,9 @@ class VatStatement(models.Model):
     def _prepare_lines(self):
         self.ensure_one()
 
-        if self.version == "2021":
+        if self.version == "2026":
+            lines = _tax_statement_dict_2026()
+        elif self.version == "2021":
             lines = _tax_statement_dict_2021()
         elif self.version == "2019":
             lines = _tax_statement_dict_2019()
@@ -189,7 +203,9 @@ class VatStatement(models.Model):
 
     def _finalize_lines(self, lines):
         self.ensure_one()
-        if self.version == "2021":
+        if self.version == "2026":
+            lines = _finalize_lines_2026(lines)
+        elif self.version == "2021":
             lines = _finalize_lines_2021(lines)
         elif self.version == "2019":
             lines = _finalize_lines_2019(lines)
@@ -416,7 +432,9 @@ class VatStatement(models.Model):
         for statement in self:
             lines = statement.line_ids
 
-            if statement.version == "2021":
+            if statement.version == "2026":
+                list_totals = _totals_2026()
+            elif statement.version == "2021":
                 list_totals = _totals_2021()
             elif statement.version == "2019":
                 list_totals = _totals_2019()
@@ -440,7 +458,9 @@ class VatStatement(models.Model):
 
     def map_tax_code_line_code(self, code):
         self.ensure_one()
-        if self.version == "2021":
+        if self.version == "2026":
+            map_tax_line_code = _map_tax_code_line_code_2026()
+        elif self.version == "2021":
             map_tax_line_code = _map_tax_code_line_code_2021()
         elif self.version == "2019":
             map_tax_line_code = _map_tax_code_line_code_2019()

--- a/l10n_de_tax_statement/models/l10n_de_tax_statement_2026.py
+++ b/l10n_de_tax_statement/models/l10n_de_tax_statement_2026.py
@@ -1,0 +1,482 @@
+# Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tools.translate import LazyTranslate
+
+_lt = LazyTranslate(__name__, default_lang="en_US")
+
+
+def _tax_statement_dict_2026():
+    return {
+        "13": {
+            "code": "13",
+            "base": 0.0,
+            "tax": 0.0,
+            "name": _lt("... zum Steuersatz von 19 % (81)"),
+        },
+        "14": {
+            "code": "14",
+            "base": 0.0,
+            "tax": 0.0,
+            "name": _lt("... zum Steuersatz von 7 % (86)"),
+        },
+        "15": {
+            "code": "15",
+            "base": 0.0,
+            "name": _lt("... zum Steuersatz von 0 % (87)"),
+        },
+        "16": {
+            "code": "16",
+            "base": 0.0,
+            "tax": 0.0,
+            "name": _lt("... zu anderen Steuersätzen (35 / 36)"),
+        },
+        "17": {
+            "code": "17",
+            "base": 0.0,
+            "name": _lt(
+                "Lieferungen land- u. forstw. Betriebe "
+                "nach § 24 UStG an Abnehmer mit USt-IdNr (77)"
+            ),
+        },
+        "18": {
+            "code": "18",
+            "base": 0.0,
+            "tax": 0.0,
+            "name": _lt(
+                "Umsätze § 24 UStG "
+                "(Sägewerke, Getränke u. alk. Flüssigkeiten) (76 / 80)"
+            ),
+        },
+        "19": {
+            "code": "19",
+            "base": 0.0,
+            "name": _lt(
+                "Innergemeinschaftliche Lieferungen "
+                "(§ 4 Nr. 1b UStG) an Abnehmer mit USt-IdNr (41)"
+            ),
+        },
+        "20": {
+            "code": "20",
+            "base": 0.0,
+            "name": _lt("Neue Fahrzeuge an Abnehmer ohne USt-IdNr (44)"),
+        },
+        "21": {
+            "code": "21",
+            "base": 0.0,
+            "name": _lt(
+                "Neue Fahrzeuge außerh. eines Unternehmens § 2a UStG (49)"
+            ),
+        },
+        "22": {
+            "code": "22",
+            "base": 0.0,
+            "name": _lt(
+                "Weitere steuerfr. Umsätze mit Vorsteuerabzug, "
+                "z.B. Ausfuhrlief., SAFE (43)"
+            ),
+        },
+        "23": {
+            "code": "23",
+            "base": 0.0,
+            "name": _lt(
+                "Steuerfreie Umsätze ohne Vorsteuerabzug "
+                "(§ 4 Nr. 8 bis 29 UStG, § 19 Abs. 1 UStG) (48)"
+            ),
+        },
+        "24": {
+            "code": "24",
+            "base": 0.0,
+            "name": _lt(
+                "Steuerfreie innergemeinschaftliche Erwerbe "
+                "(§§ 4b und 25c UStG) (91)"
+            ),
+        },
+        "25": {
+            "code": "25",
+            "base": 0.0,
+            "tax": 0.0,
+            "name": _lt(
+                "Steuerpflichtige innergemeinschaftliche Erwerbe "
+                "zum Steuersatz von 19 % (89)"
+            ),
+        },
+        "26": {
+            "code": "26",
+            "base": 0.0,
+            "tax": 0.0,
+            "name": _lt("... zum Steuersatz von 7 % (93)"),
+        },
+        "27": {
+            "code": "27",
+            "base": 0.0,
+            "name": _lt("... zum Steuersatz von 0 % (90)"),
+        },
+        "28": {
+            "code": "28",
+            "base": 0.0,
+            "tax": 0.0,
+            "name": _lt("... zu anderen Steuersätzen (95 / 98)"),
+        },
+        "29": {
+            "code": "29",
+            "base": 0.0,
+            "tax": 0.0,
+            "name": _lt(
+                "Neue Fahrzeuge (§ 1b Abs. 2 u. 3 UStG) "
+                "von Lieferern ohne USt-IdNr (94 / 96)"
+            ),
+        },
+        "30": {
+            "code": "30",
+            "base": 0.0,
+            "tax": 0.0,
+            "name": _lt(
+                "Sonst. Leistungen § 3a Abs. 2 UStG "
+                "eines im übr. Gemeinschaftsgeb. ans. Untern. "
+                "(§ 13b Abs. 1 UStG) (46 / 47)"
+            ),
+        },
+        "31": {
+            "code": "31",
+            "base": 0.0,
+            "tax": 0.0,
+            "name": _lt(
+                "Umsätze, die unter das GrEStG fallen "
+                "(§ 13b Abs. 2 Nr. 3 UStG) (73 / 74)"
+            ),
+        },
+        "32": {
+            "code": "32",
+            "base": 0.0,
+            "tax": 0.0,
+            "name": _lt(
+                "Andere Leistungen "
+                "(§ 13b Abs. 2 Nr. 1, 2, 4 bis 12 UStG) (84 / 85)"
+            ),
+        },
+        "33": {
+            "code": "33",
+            "base": 0.0,
+            "name": _lt(
+                "Lieferungen des 1. Abnehmers bei innergemeinsch. "
+                "Dreiecksgeschäften (§ 25b UStG) (42)"
+            ),
+        },
+        "34": {
+            "code": "34",
+            "base": 0.0,
+            "name": _lt(
+                "Steuerpfl. Umsätze, für die der Leistungsempfänger "
+                "die Steuer nach § 13b Abs. 5 UStG schuldet (60)"
+            ),
+        },
+        "35": {
+            "code": "35",
+            "base": 0.0,
+            "name": _lt(
+                "Nicht steuerb. sonst. Leistungen "
+                "gemäß § 18b Satz 1 Nr. 2 UStG (21)"
+            ),
+        },
+        "36": {
+            "code": "36",
+            "base": 0.0,
+            "name": _lt(
+                "Übrige nicht steuerbare Umsätze "
+                "(Leistungsort nicht im Inland) (45)"
+            ),
+        },
+        "37": {
+            "code": "37",
+            "tax": 0.0,
+            "name": _lt(
+                "Umsatzsteuer (Summe der Zeilen 13 bis 18 und 25 bis 32)"
+            ),
+        },
+        "38": {
+            "code": "38",
+            "tax": 0.0,
+            "name": _lt(
+                "Vorsteuerbeträge aus Rechnungen von anderen "
+                "Unternehmern (§ 15 Abs. 1 S. 1 Nr. 1 UStG), "
+                "aus § 27 Abs. 40a UStG und aus innergemeinsch. "
+                "Dreiecksgeschäften (§ 25b Abs. 5 UStG) (66)"
+            ),
+        },
+        "39": {
+            "code": "39",
+            "tax": 0.0,
+            "name": _lt(
+                "Vorsteuerbeträge aus dem innergemeinsch. Erwerb "
+                "von Gegenständen (§ 15 Abs. 1 S. 1 Nr. 3 UStG) (61)"
+            ),
+        },
+        "40": {
+            "code": "40",
+            "tax": 0.0,
+            "name": _lt(
+                "Entstandene Einfuhrumsatzsteuer "
+                "(§ 15 Abs. 1 S. 1 Nr. 2 UStG) (62)"
+            ),
+        },
+        "41": {
+            "code": "41",
+            "tax": 0.0,
+            "name": _lt(
+                "Vorsteuerbeträge aus Leistungen i.S.d. § 13b UStG "
+                "(§ 15 Abs. 1 S. 1 Nr. 4 UStG) (67)"
+            ),
+        },
+        "42": {
+            "code": "42",
+            "tax": 0.0,
+            "name": _lt(
+                "Vorsteuerbeträge nach allg. Durchschnittssätzen "
+                "berechnet (§ 23a UStG) (63)"
+            ),
+        },
+        "43": {
+            "code": "43",
+            "tax": 0.0,
+            "name": _lt(
+                "Vorsteuerabzug für innergemeinsch. Lief. neuer Fahrz. "
+                "außerh. eines Untern. (§ 2a UStG) sowie von "
+                "Kleinuntern. i.S.d. § 19 Abs. 1 UStG (59)"
+            ),
+        },
+        "44": {
+            "code": "44",
+            "tax": 0.0,
+            "name": _lt("Berichtigung des Vorsteuerabzugs (§ 15a UStG) (64)"),
+        },
+        "45": {
+            "code": "45",
+            "tax": 0.0,
+            "name": _lt(
+                "Verbleibender Betrag "
+                "(Zeile 37 abzüglich der Zeilen 38 bis 44)"
+            ),
+        },
+        "46": {
+            "code": "46",
+            "tax": 0.0,
+            "name": _lt(
+                "Steuer infolge Wechsels der Besteuerungsform sowie "
+                "Nachsteuer auf versteuerte Anzahlungen (65)"
+            ),
+        },
+        "47": {
+            "code": "47",
+            "tax": 0.0,
+            "name": _lt(
+                "Unrichtig/unberechtigt ausgewiesene Steuerbeträge "
+                "(§ 14c UStG) sowie § 6a Abs. 4 S. 2, "
+                "§ 17 Abs. 1 S. 7, § 25b Abs. 2, "
+                "§ 27 Abs. 40a UStG (69)"
+            ),
+        },
+        "48": {
+            "code": "48",
+            "tax": 0.0,
+            "name": _lt("Umsatzsteuer-Vorauszahlung / Überschuss (83)"),
+        },
+        "49": {
+            "code": "49",
+            "tax": 0.0,
+            "name": _lt(
+                "Abzug der festgesetzten Sondervorauszahlung "
+                "für Dauerfristverlängerung (39)"
+            ),
+        },
+        "50": {
+            "code": "50",
+            "tax": 0.0,
+            "name": _lt(
+                "Verbleibende Umsatzsteuer-Vorauszahlung / "
+                "Verbleibender Überschuss"
+            ),
+        },
+        "51": {
+            "code": "51",
+            "base": 0.0,
+            "name": _lt(
+                "Minderung der Bemessungsgrundlage "
+                "(in den Zeilen 13 bis 18 enthalten) (50)"
+            ),
+        },
+        "52": {
+            "code": "52",
+            "tax": 0.0,
+            "name": _lt(
+                "Minderung der abziehbaren Vorsteuerbeträge "
+                "(in Zeile 38 aus Rechn. v. a. Untern. sowie "
+                "Zeilen 42 u. 43 enthalten) (37)"
+            ),
+        },
+    }
+
+
+def _map_tax_code_line_code_2026():
+    return {
+        "81": "13",
+        "86": "14",
+        "87": "15",
+        "35": "16",
+        "36": "16",
+        "77": "17",
+        "76": "18",
+        "80": "18",
+        "41": "19",
+        "44": "20",
+        "49": "21",
+        "43": "22",
+        "48": "23",
+        "91": "24",
+        "89": "25",
+        "93": "26",
+        "90": "27",
+        "95": "28",
+        "98": "28",
+        "94": "29",
+        "96": "29",
+        "46": "30",
+        "47": "30",
+        "73": "31",
+        "74": "31",
+        "84": "32",
+        "85": "32",
+        "42": "33",
+        "60": "34",
+        "21": "35",
+        "45": "36",
+        "66": "38",
+        "61": "39",
+        "62": "40",
+        "67": "41",
+        "63": "42",
+        "59": "43",
+        "64": "44",
+        "65": "46",
+        "69": "47",
+        "50": "51",
+        "37": "52",
+    }
+
+
+def _finalize_lines_2026(lines):
+    _13b = lines["13"]["tax"]
+    _14b = lines["14"]["tax"]
+    _16b = lines["16"]["tax"]
+    lines["18"]["tax"] = lines["18"]["base"] * 0.19
+    _18b = lines["18"]["tax"]
+
+    _25b = lines["25"]["tax"]
+    _26b = lines["26"]["tax"]
+    lines["28"]["tax"] = lines["28"]["tax"] * -1
+    _28b = lines["28"]["tax"]
+    _29b = lines["29"]["tax"]
+
+    lines["30"]["base"] = lines["30"]["base"] * -1
+    _30b = lines["30"]["tax"]
+    lines["31"]["tax"] = lines["31"]["base"] * 0.19
+    _31b = lines["31"]["tax"]
+    lines["32"]["base"] = lines["32"]["base"] * -1
+    lines["32"]["tax"] = lines["32"]["base"] * 0.19
+    _32b = lines["32"]["tax"]
+
+    _37b = (
+        _13b + _14b + _16b + _18b + _25b + _26b + _28b + _29b
+        + _30b + _31b + _32b
+    )
+
+    lines["38"]["tax"] = lines["38"]["tax"] * -1
+    _38b = lines["38"]["tax"]
+    lines["39"]["tax"] = lines["39"]["tax"] * -1
+    _39b = lines["39"]["tax"]
+    lines["40"]["tax"] = lines["40"]["tax"] * -1
+    _40b = lines["40"]["tax"]
+    lines["41"]["tax"] = lines["41"]["tax"] * -1
+    _41b = lines["41"]["tax"]
+    lines["42"]["tax"] = lines["42"]["tax"] * -1
+    _42b = lines["42"]["tax"]
+    lines["43"]["tax"] = lines["43"]["tax"] * -1
+    _43b = lines["43"]["tax"]
+    lines["44"]["tax"] = lines["44"]["tax"] * -1
+    _44b = lines["44"]["tax"]
+
+    _45b = _37b + _38b + _39b + _40b + _41b + _42b + _43b + _44b
+
+    _46b = lines["46"]["tax"]
+    _47b = lines["47"]["tax"]
+
+    _48b = _45b + _46b + _47b
+
+    _49b = lines["49"]["tax"]
+
+    _50b = _48b - _49b
+
+    lines["37"].update({"tax": _37b})
+    lines["45"].update({"tax": _45b})
+    lines["48"].update({"tax": _48b})
+    lines["50"].update({"tax": _50b})
+
+    to_be_checked = ["13", "14", "16", "18", "25", "26", "28", "29"]
+    for code in to_be_checked:
+        tax_sign = 1 if lines[code]["tax"] >= 0.0 else -1
+        base_sign = 1 if lines[code]["base"] >= 0.0 else -1
+        if tax_sign != base_sign:
+            lines[code]["base"] *= -1
+
+    return lines
+
+
+def _totals_2026():
+    return ["48", "49"]
+
+
+def _base_display_2026():
+    return (
+        "13", "14", "15", "16", "17", "18",
+        "19", "20", "21", "22", "23",
+        "24", "25", "26", "27", "28", "29",
+        "30", "31", "32",
+        "33", "34", "35", "36",
+        "51",
+    )
+
+
+def _tax_display_2026():
+    return (
+        "13", "14", "16", "18",
+        "25", "26", "28", "29",
+        "30", "31", "32",
+        "37",
+        "38", "39", "40", "41", "42", "43", "44",
+        "45",
+        "46", "47",
+        "48", "49", "50",
+        "52",
+    )
+
+
+def _group_display_2026():
+    return ()
+
+
+def _editable_display_2026():
+    return (
+        "13", "14", "15", "16", "17", "18",
+        "19", "20", "21", "22", "23",
+        "24", "25", "26", "27", "28", "29",
+        "30", "31", "32",
+        "33", "34", "35", "36",
+        "46", "47", "49",
+        "51", "52",
+    )
+
+
+def _total_display_2026():
+    return (
+        "37", "45", "48", "50",
+    )

--- a/l10n_de_tax_statement/models/l10n_de_tax_statement_line.py
+++ b/l10n_de_tax_statement/models/l10n_de_tax_statement_line.py
@@ -27,6 +27,13 @@ from .l10n_de_tax_statement_2021 import (
     _tax_display_2021,
     _total_display_2021,
 )
+from .l10n_de_tax_statement_2026 import (
+    _base_display_2026,
+    _editable_display_2026,
+    _group_display_2026,
+    _tax_display_2026,
+    _total_display_2026,
+)
 
 
 class VatStatementLine(models.Model):
@@ -55,10 +62,14 @@ class VatStatementLine(models.Model):
     @api.depends("base", "tax", "code")
     def _compute_amount_format(self):
         for line in self:
-            if line.statement_id.version == "2021":
+            version = line.statement_id.version
+            if version == "2026":
+                base_display = _base_display_2026()
+                tax_display = _tax_display_2026()
+            elif version == "2021":
                 base_display = _base_display_2021()
                 tax_display = _tax_display_2021()
-            elif line.statement_id.version == "2019":
+            elif version == "2019":
                 base_display = _base_display_2019()
                 tax_display = _tax_display_2019()
             else:
@@ -77,10 +88,14 @@ class VatStatementLine(models.Model):
     @api.depends("code")
     def _compute_is_group(self):
         for line in self:
-            if line.statement_id.version == "2021":
+            version = line.statement_id.version
+            if version == "2026":
+                group_display = _group_display_2026()
+                total_display = _total_display_2026()
+            elif version == "2021":
                 group_display = _group_display_2021()
                 total_display = _total_display_2021()
-            elif line.statement_id.version == "2019":
+            elif version == "2019":
                 group_display = _group_display_2019()
                 total_display = _total_display_2019()
             else:
@@ -93,9 +108,12 @@ class VatStatementLine(models.Model):
     @api.depends("code")
     def _compute_is_readonly(self):
         for line in self:
-            if line.statement_id.version == "2021":
+            version = line.statement_id.version
+            if version == "2026":
+                editable_display = _editable_display_2026()
+            elif version == "2021":
                 editable_display = _editable_display_2021()
-            elif line.statement_id.version == "2019":
+            elif version == "2019":
                 editable_display = _editable_display_2019()
             else:
                 editable_display = _editable_display_2018()

--- a/l10n_de_tax_statement/readme/DESCRIPTION.md
+++ b/l10n_de_tax_statement/readme/DESCRIPTION.md
@@ -1,3 +1,5 @@
 This module provides the *German VAT Statement*
 (Umsatzsteuervoranmeldung). You can use the *German VAT Statement*
 report to declare your taxes on www.elster.de.
+
+Supported tax form versions: 2018, 2019/2020, 2021/2022, and 2026.

--- a/l10n_de_tax_statement/readme/ROADMAP.md
+++ b/l10n_de_tax_statement/readme/ROADMAP.md
@@ -9,3 +9,5 @@
 - Report in .xml format in order to import the vat statement on
   www.elster.de portal in order to avoid manual transmission of the
   values.
+- Add support for newer tax form versions as they are published by
+  the German tax authorities (BMF/ELSTER).

--- a/l10n_de_tax_statement/readme/USAGE.md
+++ b/l10n_de_tax_statement/readme/USAGE.md
@@ -3,16 +3,17 @@ To create a statement you need to:
 1.  Verify that you have enough permits. You need to belong to the *Show
     Full Accounting Features* group.
 2.  Go to the menu: Invoicing -\> Reporting \> German Tax Statement
-3.  Create a statement, providing a name and specifying start date and
-    end date
+3.  Create a statement, providing a name, specifying the tax form
+    version (2018, 2019, 2021, or 2026) and start/end date
 4.  Press the Update button to calculate the report: the report lines
     will be displayed in the tab Statement
 5.  Eventually you have to manually enter the tax base amounts of lines
-    '20', '21', '22', '23', '24','26', '27', '28', '29', '30','32',
-    '33', '34', '35', '36','38', '39', '40', '41', '42','48', '49',
-    '50', '51', '52','64', '65', '67') if you want to change the values
-    from float format to integer (in Edit mode, click on the amount of
-    the line to be able to change the value).
+    (v2026: '13', '14', '15', '16', '17', '18', '19', '20', '21',
+    '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32',
+    '33', '34', '35', '36', '46', '47', '49', '51', '52')
+    if you want to change the values from float format to integer
+    (in Edit mode, click on the amount of the line to be able to
+    change the value).
 6.  Press the Post button to set the status of the statement to Posted;
     the statements set to this state cannot be modified
 

--- a/l10n_de_tax_statement/tests/test_l10n_de_tax_statement.py
+++ b/l10n_de_tax_statement/tests/test_l10n_de_tax_statement.py
@@ -412,6 +412,55 @@ class TestVatStatement(BaseCommon):
         self.assertEqual(len(self.statement_1.line_ids.ids), 45)
         self.assertEqual(self.statement_1.tax_total, -22.5)
 
+    def test_19_2026_version(self):
+        self.assertEqual(len(self.statement_1.line_ids.ids), 0)
+        self.assertEqual(self.statement_1.tax_total, 0.0)
+
+        self._create_test_invoice()
+        self.invoice_1.action_post()
+        self.statement_1.version = "2026"
+        self.statement_1.statement_update()
+        self.statement_1.post()
+
+        self.assertEqual(len(self.statement_1.line_ids.ids), 40)
+
+        _13 = self.statement_1.line_ids.filtered(lambda r: r.code == "13")
+        _14 = self.statement_1.line_ids.filtered(lambda r: r.code == "14")
+        _37 = self.statement_1.line_ids.filtered(lambda r: r.code == "37")
+        _50 = self.statement_1.line_ids.filtered(lambda r: r.code == "50")
+
+        self.assertEqual(len(_13), 1)
+        self.assertEqual(len(_14), 1)
+        self.assertEqual(_13.format_base, "100.00")
+        self.assertEqual(_13.format_tax, "19.00")
+        self.assertEqual(_14.format_base, "50.00")
+        self.assertEqual(_14.format_tax, "3.50")
+        self.assertEqual(_50.format_tax, "22.50")
+
+        self.assertEqual(self.statement_1.tax_total, 22.5)
+        self.assertEqual(self.statement_1.format_tax_total, "22.50")
+
+    def test_20_2026_version_additional(self):
+        self.assertEqual(len(self.statement_1.line_ids.ids), 0)
+        self.assertEqual(self.statement_1.tax_total, 0.0)
+
+        self._create_test_invoice(additional=True)
+        self.invoice_1.action_post()
+        self.statement_1.version = "2026"
+        self.statement_1.statement_update()
+        self.statement_1.post()
+
+        self.assertEqual(len(self.statement_1.line_ids.ids), 40)
+
+        _30 = self.statement_1.line_ids.filtered(lambda r: r.code == "30")
+        _32 = self.statement_1.line_ids.filtered(lambda r: r.code == "32")
+        _40 = self.statement_1.line_ids.filtered(lambda r: r.code == "40")
+
+        self.assertEqual(len(_30), 1)
+        self.assertEqual(len(_32), 1)
+        self.assertEqual(len(_40), 1)
+        self.assertNotEqual(self.statement_1.tax_total, 0.0)
+
     def test_bill_dates(self):
         bill_form = self._create_move_form("in_invoice", [(100.0, self.tax_vst_19)])
         bill_form.invoice_date = "2026-04-12"


### PR DESCRIPTION
Add support for the German UStVA tax statement form version 2026 (USt 1 A) based on BMF letter III C 3 - S 7344/00039/007/036 from 2025-12-29.

Changes vs. 2021/2022 form:
- Complete line renumbering (lines 13-52 vs 17-67)
- New line 15: 0% VAT rate for photovoltaic systems (Kz 87)
- New line 27: 0% VAT rate for intra-community acquisitions PV (Kz 90)
- New line 22: includes SAFE defence industry (EU 2025/1106) (Kz 43)
- New lines 51-52: Sec. 17 UStG reductions (Kz 50, 37)
- New line 45: remaining amount (intermediate total)
- Line 17: split from line 23 for Sec. 24 deliveries to USt-IdNr (Kz 77)
- Line 18: moved from line 24 for Sec. 24 UStG (Kz 76/80)
- Line 24: new for tax-free intra-community acquisitions (Kz 91)