### PR TITLE
[18.0][IMP] l10n_de_accounting_app: add hr_expense_meal_allowance

### DIFF
--- a/l10n_de_accounting_app/config.yml
+++ b/l10n_de_accounting_app/config.yml
@@ -103,6 +103,16 @@ sections:
         label: Zusammenfassende Meldung (ZM)
         description: Extension for the Zusammenfassende Meldung (intra-community).
 
+  - name: Expense accounting (travel/meal)
+    repo: l10n-germany
+    description: null
+    addons:
+      - name: hr_expense_meal_allowance
+        label: Meal Allowance Expenses
+        description:
+          For handling meal allowances as expenses with the German standard allowance
+          rates per country and city.
+
   - name: Payment
     repo: bank-payment
     description: null

--- a/l10n_de_accounting_app/models/res_config_settings.py
+++ b/l10n_de_accounting_app/models/res_config_settings.py
@@ -17,6 +17,7 @@ _MODULE_FIELDS = [
     "module_datev_import_csv_dtvf",
     "module_l10n_de_tax_statement",
     "module_l10n_de_tax_statement_zm",
+    "module_hr_expense_meal_allowance",
     "module_account_payment_mode",
     "module_account_payment_order",
     "module_account_banking_sepa_credit_transfer",
@@ -81,6 +82,11 @@ class ResConfigSettings(models.TransientModel):
     )
     module_l10n_de_tax_statement_zm = fields.Boolean(
         string="Zusammenfassende Meldung (ZM)",
+    )
+
+    # Expense accounting (travel/meal)
+    module_hr_expense_meal_allowance = fields.Boolean(
+        string="Meal Allowance Expenses",
     )
 
     # Payment

--- a/l10n_de_accounting_app/readme/DESCRIPTION.md
+++ b/l10n_de_accounting_app/readme/DESCRIPTION.md
@@ -65,6 +65,12 @@ From [OCA/l10n-germany](https://github.com/OCA/l10n-germany):
 - **l10n_de_tax_statement** — Produces a report for manual entry into ELSTER (no API connection).
 - **l10n_de_tax_statement_zm** — Extension for the Zusammenfassende Meldung (intra-community).
 
+## Expense accounting (travel/meal)
+
+From [OCA/l10n-germany](https://github.com/OCA/l10n-germany):
+
+- **hr_expense_meal_allowance** — For handling meal allowances as expenses with the German standard allowance rates per country and city.
+
 ## Payment
 
 From [OCA/bank-payment](https://github.com/OCA/bank-payment):

--- a/l10n_de_accounting_app/views/res_config_settings_views.xml
+++ b/l10n_de_accounting_app/views/res_config_settings_views.xml
@@ -275,6 +275,25 @@
                             </div>
                         </setting>
                     </block>
+                    <block
+                        id="l10n_de_accounting_app_expense_accounting_travel_meal"
+                        title="Expense accounting (travel/meal)"
+                    >
+                        <setting
+                            id="module_hr_expense_meal_allowance"
+                            help="For handling meal allowances as expenses with the German standard allowance rates per country and city."
+                        >
+                            <field name="module_hr_expense_meal_allowance" />
+                            <div class="text-muted">
+                                Repository:
+                                <a
+                                href="https://github.com/OCA/l10n-germany"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >OCA/l10n-germany</a>
+                            </div>
+                        </setting>
+                    </block>
                     <block id="l10n_de_accounting_app_payment" title="Payment">
                         <setting id="module_account_payment_mode" help="Payment modes.">
                             <field name="module_account_payment_mode" />


### PR DESCRIPTION
Adds `hr_expense_meal_allowance` to the German accounting app so it can be installed from the app's settings page, alongside the other curated OCA addons.

Handles meal allowances (`Verpflegungsmehraufwand`) as expenses with the German standard allowance rates per country and city.

As with the other addons in this module, the change is made in `config.yml` and the model, settings view and `readme/DESCRIPTION.md` are regenerated via `dev_tools/generate.py`.

---

Following review feedback from @mt-software-de and @pniederlag, the roadmap fragment that was originally part of this PR has been split out into a dedicated tracking issue, so this PR is now scoped to the meal allowance addon only.